### PR TITLE
Issue #25: DataGrid.hideEditor should not call Focus.

### DIFF
--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -668,7 +668,6 @@ namespace PropertyTools.Wpf
 
                 this.sheetGrid.Children.Remove(this.currentEditor);
                 this.currentEditor = null;
-                this.Focus();
             }
         }
 


### PR DESCRIPTION
When it is used in Actipro docsite, when the layout is updated due to
the DataGrid lose focus, DataGrid.OnApplyTemplate will be called and
this method will be eventually called. It cause this control to be
activated again.
