### PR TITLE
Fixing issue #234 #52

### DIFF
--- a/Source/PropertyTools.Wpf/DataGrid/Operators/ListListOperator.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/Operators/ListListOperator.cs
@@ -26,6 +26,16 @@ namespace PropertyTools.Wpf
         {
         }
 
+
+        //Fixing columns change not taking effect
+        public override int GetColumnCount()
+        {
+            Owner.ColumnDefinitions.Clear();
+            AutoGenerateColumns();
+            return Owner.ColumnDefinitions.Count;
+        }
+
+
         /// <summary>
         /// Determines whether columns can be deleted.
         /// </summary>

--- a/Source/PropertyTools.Wpf/DataGrid/Operators/ListListOperator.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/Operators/ListListOperator.cs
@@ -26,7 +26,6 @@ namespace PropertyTools.Wpf
         {
         }
 
-
         //Fixing columns change not taking effect
         public override int GetColumnCount()
         {
@@ -34,7 +33,6 @@ namespace PropertyTools.Wpf
             AutoGenerateColumns();
             return Owner.ColumnDefinitions.Count;
         }
-
 
         /// <summary>
         /// Determines whether columns can be deleted.

--- a/Source/PropertyTools.Wpf/Helpers/AutoFiller.cs
+++ b/Source/PropertyTools.Wpf/Helpers/AutoFiller.cs
@@ -207,6 +207,59 @@ namespace PropertyTools.Wpf
                 }
 
                 object tmp1, tmp2, tmp3;
+
+
+                if (v1 is string && v2 is string)
+                {
+                    if (ReflectionMath.GetString_and_numbers((string)v1, out string v1str, out double v1double) && ReflectionMath.GetString_and_numbers((string)v2, out string v2str, out double v2double))
+                    {
+                        if (v1str.Equals(v2str))
+                        {
+                            
+                            ReflectionMath.TrySubtract(v2, v1, out tmp1);
+                            if (tmp1 == null)
+                            {
+                                result = null;
+                                return false;
+                            }
+
+                            ReflectionMath.TryMultiply(tmp1, f, out tmp2);
+                            if (tmp2 == null)
+                            {
+                                result = null;
+                                return false;
+                            }
+
+                            ReflectionMath.TryAdd(v1, tmp2, out tmp3);
+
+                            result = v2str + tmp3.ToString();
+
+                            return true;
+                        }
+                    }
+                }
+
+                
+
+
+                //if (o1 is string && o2 is double)
+                //{
+                //    var o11 = Regex.Match((string)o1, @"\d+$").Value;
+                //    var o22 = Regex.Match(o2.ToString(), @"\d+$").Value;
+
+                //    GetString_and_numbers((string)o1, out string outstr, out double outdouble);
+
+
+
+                //    if (int.TryParse(o11, out int o111) && double.TryParse(o22, out double o222))
+                //    {
+                //        return TryAdd(o111, o222, out result);
+                //    }
+
+                //}
+
+
+                
                 ReflectionMath.TrySubtract(v2, v1, out tmp1);
                 if (tmp1 == null)
                 {

--- a/Source/PropertyTools.Wpf/Helpers/ReflectionMath.cs
+++ b/Source/PropertyTools.Wpf/Helpers/ReflectionMath.cs
@@ -10,7 +10,9 @@
 namespace PropertyTools.Wpf
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Addition, subtraction and multiplication for all kinds of objects (by reflection to invoke the operators).
@@ -90,7 +92,68 @@ namespace PropertyTools.Wpf
                 return true;
             }
 
+            if (o1 is string && o2 is double)
+            {
+                var o11 = Regex.Match((string)o1, @"\d+$").Value;
+                var o22 = Regex.Match(o2.ToString(), @"\d+$").Value;
+
+                if (int.TryParse(o11, out int o111) && double.TryParse(o22, out double o222))
+                {
+                    return TryAdd(o111, o222, out result);
+                }
+
+            }
+
+
+
             return TryInvoke("op_Addition", o1, o2, out result);
+        }
+
+        public static bool GetString_and_numbers(string input, out string str, out double num)
+        {
+            str = string.Empty;
+            num = 0;
+            bool boolresult = false;
+
+            var stack = new Stack<char>();
+
+            for (var i = input.Length - 1; i >= 0; i--)
+            {
+                if (!char.IsNumber(input[i]))
+                {
+                    break;
+                }
+
+                stack.Push(input[i]);
+            }
+
+
+            var list = new List<char>();
+
+            for (var i = 0; i < input.Length - stack.Count; i++)
+            {
+                list.Add(input[i]);
+            }
+
+            var result = new string(stack.ToArray());
+            if (result.Length > 0)
+            {
+                boolresult = true;
+                num = double.Parse(result);
+            }
+
+            str = new string(list.ToArray());
+
+            return boolresult;
+        }
+
+        //return TryAdd(o111, o222, out result);
+
+        public static object trySomething(object o1, object o2, Func<object, object, object> action)
+        {
+
+
+            return null;
         }
 
         /// <summary>
@@ -136,6 +199,19 @@ namespace PropertyTools.Wpf
                 return true;
             }
 
+
+            if (o1 is string && o2 is string)
+            {
+                var o11 = Regex.Match((string)o1, @"\d+$").Value;
+                var o22 = Regex.Match((string)o2, @"\d+$").Value;
+
+                if (int.TryParse(o11, out int o111) && int.TryParse(o22, out int o222))
+                {
+                    return TryMultiply(o111, o222, out result);
+                }
+
+            }
+
             return TryInvoke("op_Multiply", o1, o2, out result);
         }
 
@@ -160,6 +236,20 @@ namespace PropertyTools.Wpf
             {
                 result = (int)o1 - (int)o2;
                 return true;
+            }
+
+
+
+            if (o1 is string && o2 is string)
+            {
+                var o11 = Regex.Match((string)o1, @"\d+$").Value;
+                var o22 = Regex.Match((string)o2, @"\d+$").Value;
+
+                if (int.TryParse(o11, out int o111) && int.TryParse(o22, out int o222))
+                {
+                    return TrySubtract(o111, o222, out result);
+                }
+
             }
 
             return TryInvoke("op_Subtraction", o1, o2, out result);


### PR DESCRIPTION
Fixing issue #234 #52 
Referring to above mentioned issues, I found the below code must be called to overcome and solve the bug.
Code Description
1. `Owner.ColumnDefinitions.Clear();` is necessary as if you have more than one DataGrid then ColumnDefinitions begin expanding on top of the previous DataGrid.
2. `AutoGenerateColumns();` regenerate the columns based on the new Itemsource
3. `return Owner.ColumnDefinitions.Count;` return the new number of columns.