### PR TITLE
fix for #269 Paste isn't working for DataGrid

### DIFF
--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -1415,12 +1415,11 @@ namespace PropertyTools.Wpf
                     var value = values[(i - outputRange.TopRow) % rows, (j - outputRange.LeftColumn) % columns];
                     this.TrySetCellValue(new CellRef(i, j), value);
                 }
+                // TODO: only update changed cells (or rely on bindings)
+                this.UpdateGridContent();
             }
 
-            // TODO: only update changed cells (or rely on bindings)
-            this.UpdateGridContent();
             this.suspendCollectionChangedNotifications = false;
-
             return outputRange;
         }
 


### PR DESCRIPTION
Hi Øystein,

I have found and fixed a bug in datagrid, please review the changes.

I would prefer not to make the changes in PropertyTools repo but to override them in our custom implementation.