### PR TITLE
Add IValueConverter and ToolTip lookups for property grid array/collection elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - DataGrid: Update after pasting values #269
 - TreeListBox: Fix items being added under collapsed nodes #264
+- PropertyGrid: Add IValueConverter and ToolTip lookups for property grid array/collection elements #285
 
 ### Added
 - PropertyGrid: Enhances options for PropertyGrid size #277

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - DataGrid: Update after pasting values #269
 - TreeListBox: Fix items being added under collapsed nodes #264
-- PropertyGrid: Add IValueConverter and ToolTip lookups for property grid array/collection elements #285
 
 ### Added
 - PropertyGrid: Enhances options for PropertyGrid size #277
+- PropertyGrid: Add IValueConverter and ToolTip lookups for property grid array/collection elements #285
 
 ## [3.1.0]
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,3 +26,4 @@ Sainyam Chandra <sainyam2003@gmail.com>
 verybadsoldier <vbs@springrts.de>
 William Dibbern <gotdibbs@outlook.com>
 Zoltan Rajnai <zoltan.rajnai@cognex.com>
+Travis Robinson <libusbdotnet@gmail.com>

--- a/Source/Examples/PropertyGrid/PropertyGridDemo/Converters/HexConverter.cs
+++ b/Source/Examples/PropertyGrid/PropertyGridDemo/Converters/HexConverter.cs
@@ -1,0 +1,85 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HexConverter.cs" company="PropertyTools">
+//   Copyright (c) 2021 PropertyTools contributors
+// </copyright>
+// <summary>
+//   Converts Complex instances to string instances.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ExampleLibrary
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Text.RegularExpressions;
+    using System.Windows.Data;
+
+    /// <summary>
+    /// Converts numeric and byte array instances to <see cref="string" /> hex instances.
+    /// </summary>
+    [ValueConversion(typeof(ulong), typeof(string))]
+    [ValueConversion(typeof(long), typeof(string))]
+    [ValueConversion(typeof(uint), typeof(string))]
+    [ValueConversion(typeof(int), typeof(string))]
+    [ValueConversion(typeof(ushort), typeof(string))]
+    [ValueConversion(typeof(short), typeof(string))]
+    [ValueConversion(typeof(byte), typeof(string))]
+    [ValueConversion(typeof(byte[]), typeof(string))]
+    public class HexConverter:IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is ulong u64) return $"0x{u64:X16}";
+            if (value is long i64) return $"0x{i64:X16}";
+            if (value is uint u32) return $"0x{u32:X8}";
+            if (value is int i32) return $"0x{i32:X8}";
+            if (value is ushort u16) return $"0x{u16:X4}";
+            if (value is short i16) return $"0x{i16:X4}";
+            if (value is byte b) return $"0x{b:X2}";
+            if (value is byte[] bArray)
+            {
+                return BitConverter.ToString(bArray).Replace("-", " ");
+            }
+            throw new InvalidDataException("Value cannot be converted to hex");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string s)
+            {
+                if (targetType == typeof(ulong))
+                    return ulong.Parse(s.Replace("0x", "", StringComparison.InvariantCultureIgnoreCase), NumberStyles.HexNumber);
+                if (targetType == typeof(long))
+                    return long.Parse(s.Replace("0x", "", StringComparison.InvariantCultureIgnoreCase), NumberStyles.HexNumber);
+                if (targetType == typeof(uint))
+                    return uint.Parse(s.Replace("0x", "", StringComparison.InvariantCultureIgnoreCase), NumberStyles.HexNumber);
+                if (targetType == typeof(int))
+                    return int.Parse(s.Replace("0x", "", StringComparison.InvariantCultureIgnoreCase), NumberStyles.HexNumber);
+                if (targetType == typeof(ushort))
+                    return ushort.Parse(s.Replace("0x", "", StringComparison.InvariantCultureIgnoreCase), NumberStyles.HexNumber);
+                if (targetType == typeof(short))
+                    return short.Parse(s.Replace("0x", "", StringComparison.InvariantCultureIgnoreCase), NumberStyles.HexNumber);
+                if (targetType == typeof(byte))
+                    return byte.Parse(s.Replace("0x", "", StringComparison.InvariantCultureIgnoreCase), NumberStyles.HexNumber);
+                if (targetType == typeof(byte[]))
+                {
+                    string[] hexValues = Regex.Split(s.Replace("0x",""), "[^0-9A-Fa-f]+");
+                    List<byte> byteList = new List<byte>();
+                    foreach (string hexValue in hexValues)
+                    {
+                        if (byte.TryParse(hexValue, out byte b))
+                        {
+                            byteList.Add(b);
+                        }
+                    }
+
+                    return byteList.ToArray();
+                }
+            }
+
+            throw new InvalidDataException("Value cannot be converted from hex");
+        }
+    }
+}

--- a/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CollectionsExample.cs
+++ b/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CollectionsExample.cs
@@ -45,7 +45,8 @@ namespace ExampleLibrary
         public IEnumerable<Column> CollectionItemsSourcePropertyColumns { get; } = new[]
         {
             new Column("Name", "Name", null, "2*", 'L', itemsSourcePropertyName: nameof(AvailableNames)),
-            new Column("Fraction", "%", "P2", "1*", 'R')
+            new Column("Fraction", "%", "P2", "1*", 'R'),
+            new Column("Number", "Number As Hex", null, "1*", 'R')
         };
 
         [Category("Lists|List of items with ItemsSource at property")]
@@ -73,7 +74,8 @@ namespace ExampleLibrary
         public IEnumerable<Column> Collection2Columns { get; } = new[]
         {
             new Column("Name", "Name", null, "2*", 'L'),
-            new Column("Fraction", "%", "P2", "1*", 'R')
+            new Column("Fraction", "%", "P2", "1*", 'R'),
+            new Column("Number", "Number As Hex", null, "1*", 'R')
         };
 
         [Category("Custom|Specified columns")]
@@ -132,6 +134,7 @@ namespace ExampleLibrary
         }
 
         [Description("Column header ToolTip for 'Number' column")]
+        [Converter(typeof(HexConverter))]
         public int Number
         {
             get

--- a/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CollectionsExample.cs
+++ b/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CollectionsExample.cs
@@ -118,6 +118,7 @@ namespace ExampleLibrary
 
         private double fraction;
 
+        [Description("Column header ToolTip for 'Name' column")]
         public string Name
         {
             get
@@ -130,6 +131,7 @@ namespace ExampleLibrary
             }
         }
 
+        [Description("Column header ToolTip for 'Number' column")]
         public int Number
         {
             get
@@ -142,6 +144,7 @@ namespace ExampleLibrary
             }
         }
 
+        [Description("Column header ToolTip for 'Fraction' column")]
         public double Fraction
         {
             get

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
@@ -539,12 +539,12 @@ namespace PropertyTools.Wpf
                                 {
                                     converter = Activator.CreateInstance(converterType) as IValueConverter;
                                 }
+                            }
 
-                                DataAnnotations.DescriptionAttribute descriptionAttribute = elementType.GetProperty(column.PropertyName)?.GetCustomAttribute<DataAnnotations.DescriptionAttribute>();
-                                if (descriptionAttribute != null)
-                                {
-                                    toolTip = descriptionAttribute.Description;
-                                }
+                            object[] descriptionAttributes = elementType.GetProperty(column.PropertyName)?.GetCustomAttributes(typeof(PropertyTools.DataAnnotations.DescriptionAttribute), true);
+                            if (descriptionAttributes != null && descriptionAttributes.Length > 0)
+                            {
+                                toolTip = ((DataAnnotations.DescriptionAttribute)descriptionAttributes[0]).Description;
                             }
                         }
 

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
@@ -7,8 +7,6 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System.Windows.Controls;
-
 namespace PropertyTools.Wpf
 {
     using System;
@@ -18,7 +16,6 @@ namespace PropertyTools.Wpf
     using System.ComponentModel.DataAnnotations;
     using System.Globalization;
     using System.Linq;
-    using System.Reflection;
     using System.Windows;
     using System.Windows.Data;
 

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
@@ -531,15 +531,20 @@ namespace PropertyTools.Wpf
 
                         if (elementType != null)
                         {
-                            Type converterType = elementType.GetProperty(column.PropertyName)?.GetCustomAttribute<ConverterAttribute>()?.ConverterType;
-                            if (converterType != null)
+                            object[] converterAttributes = elementType.GetProperty(column.PropertyName)?.GetCustomAttributes(typeof(ConverterAttribute), true);
+                            if (converterAttributes != null && converterAttributes.Length > 0)
                             {
-                                converter = Activator.CreateInstance(converterType) as IValueConverter;
-                            }
-                            DataAnnotations.DescriptionAttribute descriptionAttribute = elementType.GetProperty(column.PropertyName)?.GetCustomAttribute<DataAnnotations.DescriptionAttribute>();
-                            if (descriptionAttribute != null)
-                            {
-                                toolTip = descriptionAttribute.Description;
+                                Type converterType = ((ConverterAttribute)converterAttributes[0]).ConverterType;
+                                if (converterType != null)
+                                {
+                                    converter = Activator.CreateInstance(converterType) as IValueConverter;
+                                }
+
+                                DataAnnotations.DescriptionAttribute descriptionAttribute = elementType.GetProperty(column.PropertyName)?.GetCustomAttribute<DataAnnotations.DescriptionAttribute>();
+                                if (descriptionAttribute != null)
+                                {
+                                    toolTip = descriptionAttribute.Description;
+                                }
                             }
                         }
 

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
@@ -527,7 +527,6 @@ namespace PropertyTools.Wpf
                             catch
                             {
                             }
-
                         }
 
                         if (elementType != null)
@@ -542,7 +541,6 @@ namespace PropertyTools.Wpf
                             {
                                 toolTip = descriptionAttribute.Description;
                             }
-
                         }
 
                         var cd = new ColumnDefinition


### PR DESCRIPTION
For Array/ICollection properties that specify a ColumnsPropertyAttribute, try and find a "ConverterAttribute" and/or a "DescriptionAttribute" for the column property names of the array element type.  If found, use them as the DataGrid's column data converter and/or column tooltip (respectively)