### PR TITLE
Use property value converters for datagrid copy/paste operations when possible #293

### DIFF
--- a/Source/PropertyTools.Wpf/DataGrid/Operators/DataGridOperator.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/Operators/DataGridOperator.cs
@@ -519,7 +519,6 @@ namespace PropertyTools.Wpf
 
                         return true;
                     }
-
                     catch (Exception)
                     {
                     }

--- a/Source/PropertyTools.Wpf/DataGrid/Operators/DataGridOperator.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/Operators/DataGridOperator.cs
@@ -496,14 +496,15 @@ namespace PropertyTools.Wpf
                 object[] supportedConversions = pd.Converter.GetType().GetCustomAttributes(typeof(System.Windows.Data.ValueConversionAttribute), true);
                 foreach (var supportedConversion in supportedConversions)
                 {
-                    if (((System.Windows.Data.ValueConversionAttribute) supportedConversion).SourceType != targetType || 
+                    if (((System.Windows.Data.ValueConversionAttribute) supportedConversion).SourceType != targetType ||
                         ((System.Windows.Data.ValueConversionAttribute) supportedConversion).TargetType != value.GetType()) continue;
                     canUseConverter = true;
                     break;
                 }
-                try
+
+                if (canUseConverter)
                 {
-                    if (canUseConverter)
+                    try
                     {
                         convertedValue = pd.Converter.ConvertBack(value, targetType, null, CultureInfo.CurrentCulture);
                         var descriptor = this.GetPropertyDescriptor(pd, item, null);
@@ -518,10 +519,10 @@ namespace PropertyTools.Wpf
 
                         return true;
                     }
-                }
-                catch
-                {
 
+                    catch (Exception)
+                    {
+                    }
                 }
             }
 


### PR DESCRIPTION
Datagrid copy/paste operations try and use a properties value converter to convert strings to/from the properties object type.  The converter must supply ValueConversion attributes and implement both "Convert" and "ConvertBack" for this methodology to be used.  If not supported or an exception occurs, fall back to using the default conversion implementation.