### PR TITLE
[TreeListBox] Fix144# has introduced a new bug in HierarchySourceChanged event in case of Single SelectionMode

### DIFF
--- a/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
+++ b/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
@@ -510,7 +510,19 @@ namespace PropertyTools.Wpf
             var oldTreeSource = e.OldValue as IEnumerable;
             if (oldTreeSource != null)
             {
-                this.SelectedItems.Clear();
+                foreach (var item in oldTreeSource)
+                {
+                    var container = this.GetContainerFromItem(item);
+                    if (container == null)
+                    {
+                        continue;
+                    }
+
+                    if (container.IsSelected)
+                    {
+                        this.SelectedItems.Remove(item);
+                    }
+                }
             }
 
             this.ClearItems();


### PR DESCRIPTION
The commit fixing the issue Fix144# (832e8d2f07022125b1d36f76585ae13d442c5dab) regarding an expanding nodes issue ("When expanding a drive node, the folders are added at the end of the tree, not under the drive node.") has been fixed but it has introduced a new bug. The consequence is that the TreeListBox can no longer be on Single SelectionMode.
This change fix the issue and has no consequence on the previous correction.
