### PR TITLE
Return -1 if index is equal or larger than collection view count.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Fixed
 - DataGrid: Update after pasting values #269
+- DataGrid: Deleting last item in a sorted data grid causes an exception #321
 - TreeListBox: Fix items being added under collapsed nodes #264
 - Update namespace for ButtonChrome and SystemDropShadowChrome controls #316
 

--- a/Source/PropertyTools.Wpf/DataGrid/Operators/DataGridOperator.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/Operators/DataGridOperator.cs
@@ -309,10 +309,9 @@ namespace PropertyTools.Wpf
             }
 
             // get the item at the specified index in the collection view
-            // TODO: find a better way to do this
             if (!this.TryGetByIndex(collectionView, index, out var item))
             {
-                throw new InvalidOperationException("The collection view is probably out of sync. (GetItemsSourceIndex)");
+                return -1;
             }
 
             // get the index of the item in the items source


### PR DESCRIPTION
When convert the view index to source index, return -1 if the index is larger or equal to the collection view count, same behavior as collection view is empty.