### PR TITLE
Fix description icon alignment for HeaderPlacement set to Above in PropertyGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - TreeListBox: Fix items being added under collapsed nodes #264
 - Update namespace for ButtonChrome and SystemDropShadowChrome controls #316
 - DataGrid: Support for untyped lists of lists #343
+- PropertyGrid: Fix description icon alignment for HeaderPlacement set to Above #347
 
 ### Changed
 - TypeHelper.IsIListIList(Type) method changed to private #343

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGrid.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGrid.cs
@@ -1579,7 +1579,7 @@ namespace PropertyTools.Wpf
                             if (propertyControl != null)
                             {
                                 propertyPanel.RowDefinitions.Add(new System.Windows.Controls.RowDefinition());
-                                Grid.SetColumnSpan(labelPanel, 2);
+                                Grid.SetColumnSpan(labelPanel, 1);
                                 Grid.SetRow(propertyControl, 1);
                                 Grid.SetColumn(propertyControl, 0);
                                 Grid.SetColumnSpan(propertyControl, 2);

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGrid.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGrid.cs
@@ -1579,7 +1579,6 @@ namespace PropertyTools.Wpf
                             if (propertyControl != null)
                             {
                                 propertyPanel.RowDefinitions.Add(new System.Windows.Controls.RowDefinition());
-                                Grid.SetColumnSpan(labelPanel, 1);
                                 Grid.SetRow(propertyControl, 1);
                                 Grid.SetColumn(propertyControl, 0);
                                 Grid.SetColumnSpan(propertyControl, 2);


### PR DESCRIPTION
Modified Grid.SetColumnSpan for a label panel from 2 to 1 within PropertyGrid.cs addresses the misalignment of the description icon when HeaderPlacement is set to Above. This adjustment corrects the positioning of UI elements in the property grid, ensuring proper alignment and resolving the issue where the description icon was incorrectly placed at the far right.

This is a fix for the case #347 