### PR TITLE
Add `RefreshView` Property to DataGrid for Explicit Refresh + Example

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,6 +13,7 @@
 Aldinei Sampaio <aldinei.sampaio@gmail.com>
 Cyril Pyfferoen <cpyfferoen@repete.com>
 Declan Taylor <uiop456y@yandex.com>
+Deepak Arora <deepak.arora@dnv.com>
 Jeremy Liu <Jeremy.Liu@dnv.com>
 Jochen Kühner <jochen.kuehner@kardex.com>
 Jonathan Arweck <jonathan.arweck@gmail.com>

--- a/Source/Examples/DataGrid/DataGridDemo/Examples/ListOfList/ListOfListWithRowsAsUserInputExample.xaml
+++ b/Source/Examples/DataGrid/DataGridDemo/Examples/ListOfList/ListOfListWithRowsAsUserInputExample.xaml
@@ -1,0 +1,23 @@
+﻿<Window x:Class="DataGridDemo.ListOfListWithRowsAsUserInputExample"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:p="clr-namespace:PropertyTools.Wpf;assembly=PropertyTools.Wpf"
+        Title="List&lt;List&gt; (User-Input Rows)" Height="450" Width="900">
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+    <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="10">
+      <TextBox Width="100" Text="{Binding RowCount, UpdateSourceTrigger=PropertyChanged}" />
+      <Button Content="Create Rows" Command="{Binding CreateRowsCommand}" Margin="5,0,0,0"/>
+    </StackPanel>
+    <p:DataGrid ItemsSource="{Binding ItemsSource}" RefreshView="{Binding RefreshView}" Grid.Row="1">
+      <p:DataGrid.ColumnDefinitions>
+        <p:ColumnDefinition Header="A" HorizontalAlignment="Center" Width="*"/>
+        <p:ColumnDefinition Header="B" HorizontalAlignment="Center" Width="*"/>
+        <p:ColumnDefinition Header="C" HorizontalAlignment="Center" Width="*"/>
+      </p:DataGrid.ColumnDefinitions>
+    </p:DataGrid>
+  </Grid>
+</Window>

--- a/Source/Examples/DataGrid/DataGridDemo/Examples/ListOfList/ListOfListWithRowsAsUserInputExample.xaml.cs
+++ b/Source/Examples/DataGrid/DataGridDemo/Examples/ListOfList/ListOfListWithRowsAsUserInputExample.xaml.cs
@@ -1,0 +1,88 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ListOfListWithRowsAsUserInputExample.xaml.cs" company="PropertyTools">
+//   Copyright (c) 2014 PropertyTools contributors
+// </copyright>
+// <summary>
+//   Interaction logic for ListOfListWithRowsAsUserInputs.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DataGridDemo;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Input;
+
+public partial class ListOfListWithRowsAsUserInputExample : INotifyPropertyChanged
+{
+    private int rowCount;
+
+    private List<ObservableCollection<string>> itemsSource;
+
+    public ListOfListWithRowsAsUserInputExample()
+    {
+        this.InitializeComponent();
+
+        this.ItemsSource = [];
+        this.CreateRowsCommand = new RelayCommand(CreateRows);
+
+        this.DataContext = this;
+    }
+
+    public bool RefreshView => true;
+
+    public ICommand CreateRowsCommand { get; }
+
+    public int RowCount
+    {
+        get => this.rowCount;
+        set
+        {
+            this.rowCount = value;
+            OnPropertyChanged(nameof(RowCount));
+        }
+    }
+
+    public List<ObservableCollection<string>> ItemsSource
+    {
+        get => this.itemsSource;
+        set
+        {
+            this.itemsSource = value;
+            OnPropertyChanged(nameof(ItemsSource));
+        }
+    }
+
+    private void CreateRows()
+    {
+        for (var i = 0; i < RowCount; i++)
+        {
+            var row = new ObservableCollection<string> { $"Row {i + 1} - A", $"Row {i + 1} - B", $"Row {i + 1} - C" };
+            this.ItemsSource.Add(row);
+        }
+
+        this.OnPropertyChanged(nameof(RefreshView));
+    }
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+
+public class RelayCommand(Action execute, Func<bool> canExecute = null) : ICommand
+{
+    public bool CanExecute(object parameter) => canExecute == null || canExecute();
+
+    public void Execute(object parameter) => execute();
+
+    public event EventHandler CanExecuteChanged
+    {
+        add => CommandManager.RequerySuggested += value;
+        remove => CommandManager.RequerySuggested -= value;
+    }
+}

--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -416,6 +416,35 @@ namespace PropertyTools.Wpf
             new UIPropertyMetadata(false));
 
         /// <summary>
+        /// Identifies the <see cref="RefreshView"/> dependency property.
+        ///
+        /// This property is used to trigger a refresh of the <see cref="DataGrid"/> view, ensuring that the content is updated even
+        /// when the bound data source does not raise collection change notifications.
+        /// </summary>
+        /// <remarks>
+        /// The <c>RefreshView</c> property is registered with a default value of <c>false</c>.
+        ///
+        /// It is primarily used to refresh the collection view and update the grid's content in scenarios where the
+        /// <see cref="ItemsSource"/> is not implementing <see cref="INotifyCollectionChanged"/> (i.e., when the data source does not
+        /// notify changes automatically).
+        ///
+        /// The property utilizes a <see cref="CoerceValueCallback"/> to toggle the property value, forcing the update of the
+        /// <see cref="DataGrid"/> view even when the value of the <c>RefreshView</c> property itself does not change.
+        /// This ensures the grid is refreshed when explicitly requested.
+        ///
+        /// When the property changes, the <see cref="RefreshIfRequired"/> method is invoked to apply the refresh logic, ensuring the
+        /// visual state of the grid is synchronized with the underlying data.
+        /// </remarks>
+        public static readonly DependencyProperty RefreshViewProperty = DependencyProperty.Register(
+            nameof(RefreshView),
+            typeof(bool),
+            typeof(DataGrid),
+            new UIPropertyMetadata(
+                false,
+                (d, _) => ((DataGrid)d).RefreshIfRequired(),
+                (d, _) => !((DataGrid)d).RefreshView));
+
+        /// <summary>
         /// The auto fill box.
         /// </summary>
         private const string PartAutoFillBox = "PART_AutoFillBox";
@@ -1141,6 +1170,23 @@ namespace PropertyTools.Wpf
         {
             get => (bool)this.GetValue(WrapItemsProperty);
             set => this.SetValue(WrapItemsProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating the DataGrid needs to be refreshed.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> & <c>false</c> indicate that the DataGrid needs to be refreshed.
+        /// </value>
+        /// <remarks>
+        /// The property is registered with a default value of <c>false</c>.
+        /// The <see cref="CoerceValueCallback"/> toggles the property value.
+        /// This is necessary to force the update of the DataGrid view even if the value of the property does not change.
+        /// </remarks>
+        public bool RefreshView
+        {
+            get => (bool)this.GetValue(RefreshViewProperty);
+            set => this.SetValue(RefreshViewProperty, value);
         }
 
         /// <summary>


### PR DESCRIPTION
- Introduced a new `RefreshView` dependency property in the `DataGrid` class to enable explicit refresh of the grid view, especially for data sources that do not implement `INotifyCollectionChanged`.
   - The property is initialized with a default value of `false` and uses a `CoerceValueCallback` to ensure the grid is refreshed even when the property value remains unchanged.
- Added an example (`ListOfListWithRowsAsUserInputExample`) to demonstrate the new feature. This includes a new XAML file (`ListOfListWithRowsAsUserInputExample.xaml`) and its corresponding C# code-behind.
   - Implemented support for dynamic row creation with `RowCount`, `ItemsSource`, and `CreateRowsCommand` bound to the view, using `INotifyPropertyChanged` and a `RelayCommand` class for command handling.
- Updated the contributors list.