### PR TITLE
Support discard changes of the PropertyGrid

### DIFF
--- a/Source/PropertyTools.Wpf/Controls/TextBoxEx.cs
+++ b/Source/PropertyTools.Wpf/Controls/TextBoxEx.cs
@@ -137,7 +137,8 @@ namespace PropertyTools.Wpf
                             if (b != null)
                             {
                                 // update the source (do not update the target)
-                                b.UpdateSource();
+                                if (!PropertyGridControlFactory.CanDiscard)
+                                    b.UpdateSource();
                             }
                         }
 

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGrid.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGrid.cs
@@ -975,6 +975,42 @@ namespace PropertyTools.Wpf
             }
         }
 
+
+        /// <summary>
+        /// Save changes of the PropertyGrid
+        /// </summary>
+        public void SaveChanges()
+        {
+            if (PropertyGridControlFactory.CanDiscard)
+            {
+                var tabItems = this.tabControl.Items.Cast<TabItem>().ToArray();
+                foreach (var tabItem in tabItems)
+                {
+                    if (tabItem.Content is DependencyObject dependencyObj)
+                    {
+                        SaveOrDiscarcChanges(dependencyObj, true);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Discard changes of the PropertyGrid
+        /// </summary>
+        public void DiscardChanges()
+        {
+            if (PropertyGridControlFactory.CanDiscard)
+            {
+                var tabItems = this.tabControl.Items.Cast<TabItem>().ToArray();
+                foreach (var tabItem in tabItems)
+                {
+                    if (tabItem.Content is DependencyObject dependencyObj)
+                    {
+                        SaveOrDiscarcChanges(dependencyObj, false);
+                    }
+                }
+            }
+        }
         /// <summary>
         /// Gets or sets a value indicating whether to show declared properties only.
         /// </summary>
@@ -1916,6 +1952,40 @@ namespace PropertyTools.Wpf
                 {
                     this.SelectedTabId = tabItems[tabIndex].Name;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Save or Discard changes of the PropertyGrid
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="saveChanges"></param>
+        private void SaveOrDiscarcChanges(DependencyObject obj, bool saveChanges)
+        {
+            var localValueEnumerator = obj.GetLocalValueEnumerator();
+
+            while (localValueEnumerator.MoveNext())
+            {
+                var entry = localValueEnumerator.Current;
+
+                var binding = BindingOperations.GetBindingExpression(obj, entry.Property);
+
+                if (binding != null && binding.ParentBinding is Binding bind)
+                {
+                    if (bind.UpdateSourceTrigger == UpdateSourceTrigger.Explicit)
+                    {
+                        if (saveChanges)
+                            binding.UpdateSource();
+                        else
+                            binding.UpdateTarget();
+                    }
+                }
+            }
+
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
+                SaveOrDiscarcChanges(child, saveChanges); 
             }
         }
     }

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridControlFactory.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridControlFactory.cs
@@ -31,6 +31,11 @@ namespace PropertyTools.Wpf
     public class PropertyGridControlFactory : IPropertyGridControlFactory
     {
         /// <summary>
+        /// Can discard changes of PropertyGrid
+        /// </summary>
+        public static bool CanDiscard = false;
+
+        /// <summary>
         /// The font family converter
         /// </summary>
         private static readonly FontFamilyConverter FontFamilyConverter = new FontFamilyConverter();
@@ -520,6 +525,7 @@ namespace PropertyTools.Wpf
         protected virtual FrameworkElement CreateDefaultControl(PropertyItem property)
         {
             var trigger = property.AutoUpdateText ? UpdateSourceTrigger.PropertyChanged : UpdateSourceTrigger.Default;
+            if (CanDiscard) trigger = UpdateSourceTrigger.Explicit;
             var c = new TextBoxEx
             {
                 AcceptsReturn = property.AcceptsReturn,
@@ -583,6 +589,7 @@ namespace PropertyTools.Wpf
         {
             var c = new DirectoryPicker { FolderBrowserDialogService = this.FolderBrowserDialogService };
             var trigger = property.AutoUpdateText ? UpdateSourceTrigger.PropertyChanged : UpdateSourceTrigger.Default;
+            if (CanDiscard) trigger = UpdateSourceTrigger.Explicit;
             c.SetBinding(DirectoryPicker.DirectoryProperty, property.CreateBinding(trigger));
             return c;
         }
@@ -693,6 +700,7 @@ namespace PropertyTools.Wpf
             }
 
             var trigger = property.AutoUpdateText ? UpdateSourceTrigger.PropertyChanged : UpdateSourceTrigger.Default;
+            if (CanDiscard) trigger = UpdateSourceTrigger.Explicit;
             c.SetBinding(FilePicker.FilePathProperty, property.CreateBinding(trigger));
             return c;
         }
@@ -895,6 +903,7 @@ namespace PropertyTools.Wpf
             g.Children.Add(s);
 
             var trigger = property.AutoUpdateText ? UpdateSourceTrigger.PropertyChanged : UpdateSourceTrigger.Default;
+            if (CanDiscard) trigger = UpdateSourceTrigger.Explicit;
             var c = new TextBoxEx { IsReadOnly = property.Descriptor.IsReadOnly };
 
             var formatString = property.FormatString;


### PR DESCRIPTION
## Support discard changes of the PropertyGrid
+ show demo gif
![动画](https://github.com/user-attachments/assets/8a7ce9ad-f5b0-4122-96a6-30434b0539a9)

+ demo code
```csharp
public partial class MainWindow : Window
{
    Student stu = new Student();
    public MainWindow()
    {
        InitializeComponent();
        PropertyGridControlFactory.CanDiscard = true;
        stu.Name = "MornVenus";
        stu.Age = 18;

        TestPropertyGrid.SelectedObject = stu;
    }

    private void SaveChangesBtn_Click(object sender, RoutedEventArgs e)
    {
        TestPropertyGrid.SaveChanges();
    }

    private void DiscardChangesBtn_Click(object sender, RoutedEventArgs e)
    {

        TestPropertyGrid.DiscardChanges();
    }
}

public class Student
{
    public string Name { get; set; }

    public int Age { get; set; }
}
```