### PR TITLE
Collapsing a TreeItem causes application crash

### DIFF
--- a/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
+++ b/Source/PropertyTools.Wpf/TreeListBox/TreeListBox.cs
@@ -759,7 +759,7 @@ namespace PropertyTools.Wpf
             catch (ArgumentException e)
             {
                 // Workaround for #38 and #142 - it seems to kind of work if we handle this exception
-                if (e.Message == "Height must be non-negative.")
+                if (e.TargetSite?.Name == "set_Height")
                 {
                     return;
                 }


### PR DESCRIPTION
#38 and #142 was fixed by handling the ArgumentException. The solution to catch the exception by comparing the message is failing in non english countries. Instead of comparing the message text perhaps it is better to compare the name of the throwing setter. Assuming the exception is always thrown in set_Height