### PR TITLE
Add CanCopy, CanCut, CanPaste, CanDelete dependency properties to DataGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - PropertyGridDemo: Removed Fody and PropertyChanged.Fody package dependencies #TBD
 
 ### Fixed
+- DataGrid: Context menu items should be disabled when operations are not applicable #446
 - FilePicker: Fix Open button not opening files with associated applications on .NET Core/.NET 5+ #435
 - DirectoryPicker: Use full system path for explorer.exe to prevent PATH-based security vulnerabilities #433
 - FilePicker: Use full system path for explorer.exe to prevent PATH-based security vulnerabilities #433

--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -1468,7 +1468,7 @@ namespace PropertyTools.Wpf
                 if (col < this.PropertyDefinitions.Count)
                 {
                     var colDef = this.PropertyDefinitions[col];
-                    if (colDef != null && colDef.IsReadOnly == false)
+                    if (colDef != null && !colDef.IsReadOnly)
                     {
                         return true; // At least one column is editable
                     }

--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -125,6 +125,33 @@ namespace PropertyTools.Wpf
             new UIPropertyMetadata(true));
 
         /// <summary>
+        /// Identifies the <see cref="CanCopy"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty CanCopyProperty = DependencyProperty.Register(
+            nameof(CanCopy),
+            typeof(bool),
+            typeof(DataGrid),
+            new UIPropertyMetadata(true));
+
+        /// <summary>
+        /// Identifies the <see cref="CanCut"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty CanCutProperty = DependencyProperty.Register(
+            nameof(CanCut),
+            typeof(bool),
+            typeof(DataGrid),
+            new UIPropertyMetadata(true));
+
+        /// <summary>
+        /// Identifies the <see cref="CanPaste"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty CanPasteProperty = DependencyProperty.Register(
+            nameof(CanPaste),
+            typeof(bool),
+            typeof(DataGrid),
+            new UIPropertyMetadata(true));
+
+        /// <summary>
         /// Identifies the <see cref="CanDelete"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty CanDeleteProperty = DependencyProperty.Register(
@@ -424,15 +451,15 @@ namespace PropertyTools.Wpf
             nameof(LocalizableOperator),
             typeof(ILocalizableOperator),
             typeof(DataGrid),
-            new PropertyMetadata(null, (d, e) => 
+            new PropertyMetadata(null, (d, e) =>
+            {
+                var newLocalizableOperator = (ILocalizableOperator)e.NewValue;
+                var operatorValue = ((DataGrid)d).Operator;
+                if (operatorValue != null)
                 {
-                    var newLocalizableOperator = (ILocalizableOperator)e.NewValue;
-                    var operatorValue =  ((DataGrid)d).Operator;
-                    if (operatorValue != null)
-                    {
-                        operatorValue.UseLocalizableOperator(newLocalizableOperator);
-                    }
-                })
+                    operatorValue.UseLocalizableOperator(newLocalizableOperator);
+                }
+            })
             );
 
         /// <summary>
@@ -781,6 +808,36 @@ namespace PropertyTools.Wpf
         {
             get => (bool)this.GetValue(CanClearProperty);
             set => this.SetValue(CanClearProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this grid can copy cells.
+        /// </summary>
+        /// <value><c>true</c> if this instance can copy; otherwise, <c>false</c> .</value>
+        public bool CanCopy
+        {
+            get => (bool)this.GetValue(CanCopyProperty);
+            set => this.SetValue(CanCopyProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this grid can cut cells.
+        /// </summary>
+        /// <value><c>true</c> if this instance can cut; otherwise, <c>false</c> .</value>
+        public bool CanCut
+        {
+            get => (bool)this.GetValue(CanCutProperty);
+            set => this.SetValue(CanCutProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this grid can paste cells.
+        /// </summary>
+        /// <value><c>true</c> if this instance can paste; otherwise, <c>false</c> .</value>
+        public bool CanPaste
+        {
+            get => (bool)this.GetValue(CanPasteProperty);
+            set => this.SetValue(CanPasteProperty, value);
         }
 
         /// <summary>
@@ -1347,10 +1404,10 @@ namespace PropertyTools.Wpf
             this.UpdateGridContent();
             this.SelectedCellsChanged();
 
-            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Copy, (s, e) => this.Copy()));
-            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Cut, (s, e) => this.Cut()));
-            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Paste, (s, e) => this.Paste()));
-            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Delete, (s, e) => this.Clear(), (s, e) => e.CanExecute = this.CanClear));
+            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Copy, (s, e) => this.Copy(), (s, e) => e.CanExecute = this.CanCopy && this.HasValidSelection()));
+            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Cut, (s, e) => this.Cut(), (s, e) => e.CanExecute = this.CanCut && this.CanModifySelection()));
+            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Paste, (s, e) => this.Paste(), (s, e) => e.CanExecute = this.CanPaste && this.CanModifySelection() && this.ClipboardContainsText()));
+            this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Delete, (s, e) => this.Clear(), (s, e) => e.CanExecute = this.CanClear && this.CanModifySelection()));
         }
 
         /// <summary>
@@ -1380,6 +1437,62 @@ namespace PropertyTools.Wpf
         public void Paste()
         {
             this.PasteOverride();
+        }
+
+        /// <summary>
+        /// Determines whether there is a valid cell selection.
+        /// </summary>
+        /// <returns><c>true</c> if there is a valid selection; otherwise, <c>false</c>.</returns>
+        protected virtual bool HasValidSelection()
+        {
+            var range = this.GetSelectionRange();
+            return range.TopRow >= 0 && range.LeftColumn >= 0;
+        }
+
+        /// <summary>
+        /// Determines whether the current selection can be modified (not read-only).
+        /// Checks column-level IsReadOnly for all columns in the selection.
+        /// </summary>
+        /// <returns><c>true</c> if at least one cell in selection is editable; otherwise, <c>false</c>.</returns>
+        protected virtual bool CanModifySelection()
+        {
+            var range = this.GetSelectionRange();
+            if (range.TopRow < 0 || range.LeftColumn < 0)
+            {
+                return false;
+            }
+
+            // Check if any column in the selection is editable
+            for (var col = range.LeftColumn; col <= range.RightColumn; col++)
+            {
+                if (col < this.PropertyDefinitions.Count)
+                {
+                    var colDef = this.PropertyDefinitions[col];
+                    if (colDef != null && colDef.IsReadOnly == false)
+                    {
+                        return true; // At least one column is editable
+                    }
+                }
+            }
+
+            return false; // All columns in selection are read-only
+        }
+
+        /// <summary>
+        /// Determines whether the clipboard contains text.
+        /// </summary>
+        /// <returns><c>true</c> if clipboard contains text; otherwise, <c>false</c>.</returns>
+        protected virtual bool ClipboardContainsText()
+        {
+            try
+            {
+                return Clipboard.ContainsText();
+            }
+            catch
+            {
+                // Clipboard may be locked by another process
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #446

Add new dependency properties to enable explicit control over clipboard and delete command availability in PropertyTools DataGrid:

- CanCopyProperty: Controls whether Copy command is enabled (default: true)
- CanCutProperty: Controls whether Cut command is enabled (default: true)
- CanPasteProperty: Controls whether Paste command is enabled (default: true)
- CanDeleteProperty: Controls whether Delete command is enabled (default: true)

These properties follow the existing CanClear pattern and allow consumers to bind these values from ViewModels for scenarios like read-only grids.

The properties are designed to work with a hybrid approach where:
- DPs provide explicit binding control for consumers
- Runtime checks (to be added) provide automatic state validation
- CanExecute = DependencyProperty && RuntimeStateCheck()

This enables context menu items to properly grey out when operations are not applicable, improving UX for read-only data display scenarios.

Related: PropertyTools enhancement proposal for clipboard command handlers