### PR TITLE
Fix DataGrid Shift+Click and Click false range-selection in scrollable hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - PropertyGridDemos: Added SelectedObjectsExample demonstrating ObservableCollection binding to PropertyGrid.SelectedObjects #267
 
 ### Fixed
+- DataGrid: Fixed selection extending on simple click when hosted in a scrollable container #478
 - TreeListBox: Fixed crash when used in TabControl - resolved race condition where collection events fired before parent items were initialized during deferred loading #312
 - PropertyGrid: Fixed SelectedObjects binding not working - initialization logic now properly sets CurrentObject when binding ObservableCollection #267
 - TreeListBox: Fixed multiple root items expansion issue where children were incorrectly displayed under the last root item instead of their respective parent #282

--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -645,6 +645,17 @@ namespace PropertyTools.Wpf
         private bool endPressed;
 
         /// <summary>
+        /// The mouse position in screen coordinates when left button was pressed.
+        /// Used to distinguish click from drag even when control coordinates shift during scroll.
+        /// </summary>
+        private Point? mouseDownPositionOnScreen;
+
+        /// <summary>
+        /// Indicates whether a range-selection drag has started for the current mouse capture.
+        /// </summary>
+        private bool isRangeSelectionDrag;
+
+        /// <summary>
         /// The sheet grid control.
         /// </summary>
         private Grid sheetGrid;
@@ -1571,7 +1582,7 @@ namespace PropertyTools.Wpf
             // Use Operator.GetRowCount() instead of this.Rows to work in test environments
             var currentRowCount = this.Operator?.GetRowCount() ?? 0;
             var newRowsNeeded = Math.Max(0, outputRange.BottomRow - currentRowCount + 1);
-            
+
             // Phase 2: Add new rows at the end of the source collection
             for (var rowIndex = 0; rowIndex < newRowsNeeded; rowIndex++)
             {
@@ -1825,6 +1836,9 @@ namespace PropertyTools.Wpf
             this.Focus();
             base.OnMouseLeftButtonDown(e);
 
+            this.mouseDownPositionOnScreen = this.PointToScreen(e.GetPosition(this));
+            this.isRangeSelectionDrag = false;
+
             var pos = e.GetPosition(this.sheetGrid);
             var cellRef = this.GetCell(pos);
 
@@ -1854,6 +1868,7 @@ namespace PropertyTools.Wpf
                 if (!this.HandleAutoInsert(cellRef))
                 {
                     var shift = (Keyboard.Modifiers & ModifierKeys.Shift) != ModifierKeys.None;
+                    this.isRangeSelectionDrag = false;
                     if (!shift)
                     {
                         this.CurrentCell = cellRef;
@@ -1877,6 +1892,9 @@ namespace PropertyTools.Wpf
         protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
         {
             this.OnMouseUp(e);
+
+            this.mouseDownPositionOnScreen = null;
+            this.isRangeSelectionDrag = false;
 
             this.ReleaseMouseCapture();
             Mouse.OverrideCursor = null;
@@ -1904,6 +1922,26 @@ namespace PropertyTools.Wpf
             }
 
             var isInAutoFillMode = this.autoFillSelection.Visibility == Visibility.Visible;
+
+            if (!isInAutoFillMode)
+            {
+                if (!this.isRangeSelectionDrag)
+                {
+                    var currentPositionOnScreen = this.PointToScreen(e.GetPosition(this));
+                    if (this.mouseDownPositionOnScreen.HasValue)
+                    {
+                        var horizontalDragDistance = Math.Abs(currentPositionOnScreen.X - this.mouseDownPositionOnScreen.Value.X);
+                        var verticalDragDistance = Math.Abs(currentPositionOnScreen.Y - this.mouseDownPositionOnScreen.Value.Y);
+                        if (horizontalDragDistance < SystemParameters.MinimumHorizontalDragDistance
+                            && verticalDragDistance < SystemParameters.MinimumVerticalDragDistance)
+                        {
+                            return;
+                        }
+                    }
+
+                    this.isRangeSelectionDrag = true;
+                }
+            }
 
             var pos = e.GetPosition(this.sheetGrid);
             var cellRef = this.GetCell(pos, isInAutoFillMode, this.CurrentCell);

--- a/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
+++ b/Source/PropertyTools.Wpf/DataGrid/DataGrid.cs
@@ -1868,7 +1868,6 @@ namespace PropertyTools.Wpf
                 if (!this.HandleAutoInsert(cellRef))
                 {
                     var shift = (Keyboard.Modifiers & ModifierKeys.Shift) != ModifierKeys.None;
-                    this.isRangeSelectionDrag = false;
                     if (!shift)
                     {
                         this.CurrentCell = cellRef;


### PR DESCRIPTION
---
Case:  
#478

## Description

Fixes unintended multi-row selection when Shift+Clicking or just clicking a cell in a partially visible DataGrid inside a scrollable container. The issue occurred because focus/auto-scroll during the click shifted control-relative mouse coordinates, which the old logic misinterpreted as a drag, leading to accidental range selection even without intentional mouse movement.

## Related Issue

Fixes #478

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Modified `OnMouseLeftButtonDown` to store mouse-down position in screen coordinates (`PointToScreen`) and always initialize `isRangeSelectionDrag` to `false` (removing pre-enabling on Shift key).
- Updated `OnMouseMove` to compare current screen coordinates against the stored position and only enable range-selection drag after exceeding system drag thresholds (`SystemParameters.MinimumHorizontalDragDistance` / `MinimumVerticalDragDistance`).
- Ensures click-vs-drag detection remains stable during layout shifts (e.g., scrolling or focus changes), while preserving Shift+Click, Shift+drag, and auto-fill behaviors.

## Testing

- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing performed

### Test Details

- Reproduced the original issue: Placed DataGrid inside a vertically scrollable container (e.g., ScrollViewer), made it partially visible, and Shift+Clicked a cell near the clipped edge — confirmed no unintended range selection occurs unless the pointer is actually dragged beyond the system threshold.
- Verified normal Shift+Click or click within a fully visible grid still sets the correct selection anchor.
- Confirmed Shift+drag still performs expected range selection once movement exceeds thresholds.
- Ran existing unit tests for DataGrid mouse handling; no regressions observed.

## Code Quality Checklist

- [x] Code follows the project's style guidelines (see [copilot-instructions.md](https://github.com/PropertyTools/PropertyTools/blob/develop/.github/copilot-instructions.md))
- [ ] Copyright headers added to new files
- [x] XML documentation added for public APIs
- [x] Code builds successfully with no warnings
- [x] All tests pass locally
- [x] Meaningful variable and method names used
- [x] Code is compatible with .NET Framework 4.6.2 and .NET 8+ Windows

## Documentation

- [x] **CHANGELOG.md updated** under the `## Unreleased` section with appropriate category (Fixed: DataGrid Shift+Click false range-selection in scrollable hosts)
- [ ] CONTRIBUTORS file updated (if new contributor)
- [ ] README.md updated (if new control or major feature)
- [x] Code includes appropriate comments where needed

## Additional Notes

This is a low-risk, localized fix to mouse event handling in `DataGrid.cs`. No breaking changes to public APIs or behaviors. The fix addresses a common issue in property-panel layouts where grids are hosted in scrollable containers.

## Screenshots (if applicable)

<!-- No UI changes; behavior fix only -->

## Breaking Changes

<!-- None -->
