### PR TITLE
Raise Closing event in PropertyDialog

### DIFF
--- a/Source/Examples/Controls/DialogDemos/ClosingEventExampleViewModels.cs
+++ b/Source/Examples/Controls/DialogDemos/ClosingEventExampleViewModels.cs
@@ -1,0 +1,80 @@
+﻿using System.ComponentModel;
+
+namespace DialogDemos
+{
+	/// <remarks>
+	/// Properties are not needed for OnClosingEvent example #1
+	/// </remarks>
+	public class ClosingEventExampleViewModels : PropertyTools.Observable
+	{ 
+	}
+
+	public class ClosingEventExample2ViewModel : PropertyTools.Observable
+	{
+		private bool _cancelOnClosingFlag;
+
+		[Category("Flags|General")]
+		[DisplayName("Cancel On Closing")]
+		public bool CancelOnClosingFlag
+		{
+			get
+			{
+				return _cancelOnClosingFlag;
+			}
+			set
+			{
+				base.SetValue(ref _cancelOnClosingFlag, value);
+			}
+		}
+	}
+
+
+	public class ClosingEventExample3ViewModel : PropertyTools.Observable, IEditableObject
+	{
+		private string _username;
+
+		[Category("General|Credentials")]
+		[DisplayName("Username")]
+		public string Username
+		{
+			get
+			{
+				return _username;
+			}
+			set
+			{
+				base.SetValue(ref _username, value);
+			}
+		}
+
+		#region IEditableObject
+
+		private ClosingEventExample3ViewModel _backup;
+		private bool _isEditing;
+
+		public void BeginEdit()
+		{
+			if (_isEditing) return;
+			_isEditing = true;
+			// Simple snapshot: copy current values
+			_backup = new ClosingEventExample3ViewModel { Username = this.Username };
+		}
+
+		public void EndEdit()
+		{
+			if (!_isEditing) return;
+			_isEditing = false;
+			_backup = null; // Discard backup
+		}
+
+		public void CancelEdit()
+		{
+			if (!_isEditing) return;
+			_isEditing = false;
+			// Restore from backup
+			this.Username = _backup.Username;
+		}
+
+		#endregion
+	}
+}

--- a/Source/Examples/Controls/DialogDemos/ClosingEventExampleViewModels.cs
+++ b/Source/Examples/Controls/DialogDemos/ClosingEventExampleViewModels.cs
@@ -1,17 +1,17 @@
-﻿using System.ComponentModel;
-
-namespace DialogDemos
+﻿namespace DialogDemos
 {
-	/// <remarks>
-	/// Properties are not needed for OnClosingEvent example #1
-	/// </remarks>
-	public class ClosingEventExampleViewModels : PropertyTools.Observable
+    using System.ComponentModel;
+
+    /// <remarks>
+    /// Properties are not needed for OnClosingEvent example #1
+    /// </remarks>
+    public class ClosingEventExampleViewModels : PropertyTools.Observable
 	{ 
 	}
 
 	public class ClosingEventExample2ViewModel : PropertyTools.Observable
 	{
-		private bool _cancelOnClosingFlag;
+		private bool cancelOnClosingFlag;
 
 		[Category("Flags|General")]
 		[DisplayName("Cancel On Closing")]
@@ -19,11 +19,11 @@ namespace DialogDemos
 		{
 			get
 			{
-				return _cancelOnClosingFlag;
+				return this.cancelOnClosingFlag;
 			}
 			set
 			{
-				base.SetValue(ref _cancelOnClosingFlag, value);
+				base.SetValue(ref this.cancelOnClosingFlag, value);
 			}
 		}
 	}
@@ -31,7 +31,7 @@ namespace DialogDemos
 
 	public class ClosingEventExample3ViewModel : PropertyTools.Observable, IEditableObject
 	{
-		private string _username;
+		private string username;
 
 		[Category("General|Credentials")]
 		[DisplayName("Username")]
@@ -39,42 +39,38 @@ namespace DialogDemos
 		{
 			get
 			{
-				return _username;
+				return this.username;
 			}
 			set
 			{
-				base.SetValue(ref _username, value);
+				base.SetValue(ref this.username, value);
 			}
 		}
 
-		#region IEditableObject
-
-		private ClosingEventExample3ViewModel _backup;
-		private bool _isEditing;
+		private ClosingEventExample3ViewModel backup;
+		private bool isEditing;
 
 		public void BeginEdit()
 		{
-			if (_isEditing) return;
-			_isEditing = true;
+			if (this.isEditing) return;
+			this.isEditing = true;
 			// Simple snapshot: copy current values
-			_backup = new ClosingEventExample3ViewModel { Username = this.Username };
+			this.backup = new ClosingEventExample3ViewModel { Username = this.Username };
 		}
 
 		public void EndEdit()
 		{
-			if (!_isEditing) return;
-			_isEditing = false;
-			_backup = null; // Discard backup
+			if (!isEditing) return;
+			this.isEditing = false;
+			this.backup = null; // Discard backup
 		}
 
 		public void CancelEdit()
 		{
-			if (!_isEditing) return;
-			_isEditing = false;
+			if (!isEditing) return;
+			this.isEditing = false;
 			// Restore from backup
-			this.Username = _backup.Username;
+			this.Username = this.backup.Username;
 		}
-
-		#endregion
 	}
 }

--- a/Source/Examples/Controls/DialogDemos/OnClosingEventExample1ViewModel.cs
+++ b/Source/Examples/Controls/DialogDemos/OnClosingEventExample1ViewModel.cs
@@ -1,9 +1,0 @@
-﻿namespace DialogDemos
-{
-	/// <remarks>
-	/// Properties are not needed for OnClosingEvent example #1
-	/// </remarks>
-	public class OnClosingEventExample1ViewModel : PropertyTools.Observable
-	{ 
-	}
-}

--- a/Source/Examples/Controls/DialogDemos/OnClosingEventExample1ViewModel.cs
+++ b/Source/Examples/Controls/DialogDemos/OnClosingEventExample1ViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace DialogDemos
+{
+	/// <remarks>
+	/// Properties are not needed for OnClosingEvent example #1
+	/// </remarks>
+	public class OnClosingEventExample1ViewModel : PropertyTools.Observable
+	{ 
+	}
+}

--- a/Source/Examples/Controls/DialogDemos/Person.cs
+++ b/Source/Examples/Controls/DialogDemos/Person.cs
@@ -4,30 +4,29 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System.ComponentModel;
-
 namespace DialogDemos
 {
+    using System.ComponentModel;
 
     public class Person : Observable
     {
-        private string _firstName;
+        private string firstName;
         public string FirstName
         {
-            get { return _firstName; }
-            set { _firstName = value; OnPropertyChanged(nameof(FirstName)); }
+            get { return this.firstName; }
+            set { this.firstName = value; OnPropertyChanged(nameof(FirstName)); }
         }
 
-        private string _lastName;
+        private string lastName;
         public string LastName
         {
-            get { return _lastName; }
-            set { _lastName = value; OnPropertyChanged(nameof(LastName)); }
+            get { return this.lastName; }
+            set { this.lastName = value; OnPropertyChanged(nameof(LastName)); }
         }
 
         public override string ToString()
         {
-            return FirstName + " " + LastName;
+            return this.FirstName + " " + this.LastName;
         }
     }
 
@@ -37,7 +36,7 @@ namespace DialogDemos
         {
             if (PropertyChanged != null)
             {
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+                this.PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
             }
         }
 

--- a/Source/Examples/Controls/DialogDemos/Window1.xaml
+++ b/Source/Examples/Controls/DialogDemos/Window1.xaml
@@ -20,7 +20,12 @@
             <MenuItem Header="Help">
                 <MenuItem Header="About..." Click="About_Click"/>
             </MenuItem>
-        </Menu>
+
+			<MenuItem Header="Examples">
+				<MenuItem Header="OnClosing Event 1..." Click="OnClosingEventExample1_Click"/>
+			</MenuItem>
+
+		</Menu>
         <pt:PropertyGrid SelectedObject="{Binding}" Margin="4"/>
     </DockPanel>
 </Window>

--- a/Source/Examples/Controls/DialogDemos/Window1.xaml
+++ b/Source/Examples/Controls/DialogDemos/Window1.xaml
@@ -22,7 +22,9 @@
             </MenuItem>
 
 			<MenuItem Header="Examples">
-				<MenuItem Header="OnClosing Event 1..." Click="OnClosingEventExample1_Click"/>
+				<MenuItem Header="Closing Event 1..." Click="ClosingEventExample1_Click"/>
+				<MenuItem Header="Closing Event 2..." Click="ClosingEventExample2_Click"/>
+				<MenuItem Header="Closing Event 3..." Click="ClosingEventExample3_Click"/>
 			</MenuItem>
 
 		</Menu>

--- a/Source/Examples/Controls/DialogDemos/Window1.xaml.cs
+++ b/Source/Examples/Controls/DialogDemos/Window1.xaml.cs
@@ -80,8 +80,6 @@ namespace DialogDemos
             dlg.ShowDialog();
         }
 
-		#region ClosingEvent Examples
-
 		private void ClosingEventExample1_Click(object sender, RoutedEventArgs e)
 		{
 			var model = new ClosingEventExampleViewModels();
@@ -174,8 +172,6 @@ namespace DialogDemos
 
 			dlg.ShowDialog();
 		}
-
-		#endregion
 	}
 
 	public enum StartupAction

--- a/Source/Examples/Controls/DialogDemos/Window1.xaml.cs
+++ b/Source/Examples/Controls/DialogDemos/Window1.xaml.cs
@@ -79,9 +79,35 @@ namespace DialogDemos
 
             dlg.ShowDialog();
         }
-    }
 
-    public enum StartupAction
+		private void OnClosingEventExample1_Click(object sender, RoutedEventArgs e)
+		{
+			var model = new OnClosingEventExample1ViewModel();
+			var dlg = new PropertyDialog
+			{
+				Owner = this,
+				DataContext = model,
+				Title = "OnClosing Event Example 1"
+			};
+
+			int closingAttempt = 0;
+
+			dlg.Closing += (s, e) =>
+			{
+				closingAttempt++;
+				e.Cancel = closingAttempt == 2;
+			};
+
+			dlg.Closed += (s, e) =>
+			{
+				MessageBox.Show("Dialog was closed. Total attempts= " + closingAttempt);
+			};
+
+			dlg.ShowDialog();
+		}
+	}
+
+	public enum StartupAction
     {
         NewProject,
         OpenProject,

--- a/Source/Examples/Controls/DialogDemos/Window1.xaml.cs
+++ b/Source/Examples/Controls/DialogDemos/Window1.xaml.cs
@@ -80,9 +80,11 @@ namespace DialogDemos
             dlg.ShowDialog();
         }
 
-		private void OnClosingEventExample1_Click(object sender, RoutedEventArgs e)
+		#region ClosingEvent Examples
+
+		private void ClosingEventExample1_Click(object sender, RoutedEventArgs e)
 		{
-			var model = new OnClosingEventExample1ViewModel();
+			var model = new ClosingEventExampleViewModels();
 			var dlg = new PropertyDialog
 			{
 				Owner = this,
@@ -105,6 +107,75 @@ namespace DialogDemos
 
 			dlg.ShowDialog();
 		}
+
+		private void ClosingEventExample2_Click(object sender, RoutedEventArgs e)
+		{
+			var model = new ClosingEventExample2ViewModel();
+			var dlg = new PropertyDialog
+			{
+				Owner = this,
+				OkButtonDataErrorAware = true,
+				DataContext = model,
+				Title = "OnClosing Event Example 2"
+			};
+
+			int closingAttempt = 0;
+
+			dlg.Closing += (s, e) =>
+			{
+				closingAttempt++;
+				if (e is PropertyDialogCancelEventArgs customCancelEventArgs)
+				{
+					var editingContext = (ClosingEventExample2ViewModel)customCancelEventArgs.EditingContext;
+					e.Cancel = editingContext.CancelOnClosingFlag;
+				}
+			};
+
+			dlg.Closed += (s, e) =>
+			{
+				MessageBox.Show("Dialog was closed. Total attempts= " + closingAttempt);
+			};
+
+			dlg.ShowDialog();
+		}
+
+		private void ClosingEventExample3_Click(object sender, RoutedEventArgs e)
+		{
+			var existingUsername = "pt_user";
+			var model = new ClosingEventExample3ViewModel()
+			{
+				Username = existingUsername
+			};
+			var dlg = new PropertyDialog
+			{
+				Owner = this,
+				DataContext = model,
+				Title = "Add New User"
+			};
+
+			dlg.Closing += (s, e) =>
+			{
+				// perform validation when OK button has been clicked.
+				if (e is PropertyDialogCancelEventArgs customCancelEventArgs 
+					&& customCancelEventArgs.DialogResult == true
+					)
+				{
+					var editingContext = (ClosingEventExample3ViewModel)customCancelEventArgs.EditingContext;
+
+					// username must be different that existing					
+					if (editingContext.Username.Equals(existingUsername, StringComparison.OrdinalIgnoreCase))
+					{
+						MessageBox.Show("User with same name already exists. Please choose a different one", "Invalid Username", 
+							MessageBoxButton.OK, MessageBoxImage.Information);
+						e.Cancel = true;
+					}
+				}
+			};
+
+			dlg.ShowDialog();
+		}
+
+		#endregion
 	}
 
 	public enum StartupAction

--- a/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CategoryAttributeOrderedExample.cs
+++ b/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CategoryAttributeOrderedExample.cs
@@ -29,8 +29,6 @@ namespace ExampleLibrary
 		private int numberX = 10;
 		private int numberL = 50;
 
-		#region Hundreds / D
-
 		[ReadOnly(true)]
 		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category D", tabSortIndex: 1, groupSortIndex: 1)]		
 		public int NumberD { get => this.numberD; set { this.numberD = value; this.RaisePropertyChanged(nameof(NumberD)); } }
@@ -46,10 +44,6 @@ namespace ExampleLibrary
 		[ReadOnly(true)]
 		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category D", tabSortIndex: 1, groupSortIndex: 1)]		
 		public int NumberDCCC { get => this.numberDCCC; set { this.numberDCCC = value; this.RaisePropertyChanged(nameof(NumberDCCC)); } }
-
-		#endregion
-
-		#region Hundreds / C
 
 		[ReadOnly(true)]
 		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category C", tabSortIndex: 1)]		
@@ -71,23 +65,12 @@ namespace ExampleLibrary
 		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category C", tabSortIndex: 1)]
 		public int NumberCM { get => this.numberCM; set { this.numberCM = value; this.RaisePropertyChanged(nameof(NumberCM)); } }
 
-		#endregion
-
-
-		#region Tens / L
-
 		[ReadOnly(true)]
 		[PropertyTools.DataAnnotations.Category("Tens (Roman)|Category L", 0, 1)]
 		public int NumberL { get => this.numberL; set { this.numberL = value; this.RaisePropertyChanged(nameof(NumberL)); } }
 
-		#endregion
-
-		#region Tens / X
-
 		[ReadOnly(true)]
 		[PropertyTools.DataAnnotations.Category("Tens (Roman)|Category X", 0, 0)]
 		public int NumberX { get => this.numberX; set { this.numberX = value; this.RaisePropertyChanged(nameof(NumberX)); } }
-
-		#endregion
 	}
 }

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml
@@ -15,7 +15,8 @@
   <DockPanel>
     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="8">
       <Button Name="OkButton" IsDefault="True" Click="OkButtonClick" Content="OK" />
-      <Button Name="CancelButton" IsCancel="True" Click="CancelButtonClick" Content="Cancel" />
+	  <!-- Click="CancelButtonClick" is not needed when IsCancel="True"  -->
+      <Button Name="CancelButton" IsCancel="True" Content="Cancel" />
       <Button Name="ApplyButton" Click="ApplyButtonClick" Content="Apply" />
       <Button Name="CloseButton" Click="CloseButtonClick" Content="Close" />
       <Button Name="HelpButton" Click="HelpButtonClick" Content="Help" />

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
@@ -168,7 +168,8 @@ namespace PropertyTools.Wpf
             
             if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
             {
-                nde.ErrorsChanged += DataErrorsChanged;
+				nde.ErrorsChanged -= DataErrorsChanged;
+				nde.ErrorsChanged += DataErrorsChanged;
                 this.SetDataErrorAwareButtons();
             }
         }
@@ -221,7 +222,7 @@ namespace PropertyTools.Wpf
         /// <summary>
         /// Ends the edit.
         /// </summary>
-        private void EndEdit()
+        protected void EndEdit()
         {
             var editableDataContext = this.DataContext as IEditableObject;
 
@@ -235,16 +236,24 @@ namespace PropertyTools.Wpf
             }
         }
 
-        /// <summary>
-        /// Handles the Click event of the Cancel button.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The e.</param>
-        private void CancelButtonClick(object sender, RoutedEventArgs e)
+		/// <summary>
+		/// Handles the Click event of the Cancel button.
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The e.</param>
+		/// <remarks>
+		/// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
+		/// </remarks>
+		private void CancelButtonClick(object sender, RoutedEventArgs e)
         {
-            this.DialogResult = false;
-            this.CancelEdit();
-            this.Close();
+			this.isClosedAlready_ButtonClickScope = false; // reset flag
+
+			this.DialogResult = false; // also will call Close() method when DialogResult != false
+
+			if (!this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
+			{
+				this.Close();
+			}
         }
 
         /// <summary>
@@ -266,39 +275,80 @@ namespace PropertyTools.Wpf
         {
         }
 
-        /// <summary>
-        /// Handles the Click event of the Ok button.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The event arguments.</param>
-        private void OkButtonClick(object sender, RoutedEventArgs e)
+		/// <summary>
+		/// Flag determines whether or not dialog was closed already.<para/>
+		/// Suffix (scope) indicates that flag value must be checked only in 
+        /// <see cref="OkButtonClick(object, RoutedEventArgs)"/> and <see cref="CloseButtonClick(object, RoutedEventArgs)"/>. <para/>
+		/// Helps to prevent raising the <see cref="System.Windows.Window.Closed"/> event twice.
+		/// </summary>
+		/// <remarks>
+		/// Flag must be set in <see cref="OnClosed(EventArgs)"/> only
+		/// </remarks>
+		private bool isClosedAlready_ButtonClickScope;
+
+		/// <summary>
+		/// Handles the Click event of the Ok button.
+		/// </summary>        
+		/// <param name="sender">The sender.</param>        
+		/// <param name="e">The event arguments.</param>
+		/// <remarks>
+        /// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
+		/// </remarks>
+		private void OkButtonClick(object sender, RoutedEventArgs e)
         {
-            this.DialogResult = true;
-            this.EndEdit();
-            this.Close();
+            this.isClosedAlready_ButtonClickScope = false; // reset flag
+			
+			this.DialogResult = true;  // also will call Close() method when DialogResult != true
+
+			if (!this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
+            {
+                this.Close();
+            }
         }
 
-        /// <summary>
-        /// Handles the Changed event of the DataContext.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The event arguments.</param>
-        private void PropertyDialogDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+		/// <summary>
+		/// Handles the Changed event of the DataContext.
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The event arguments.</param>
+		private void PropertyDialogDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             this.BeginEdit();
         }
 
-        /// <summary>
-        /// Handles the Closing event of the PropertyDialog control.
-        /// </summary>
-        /// <param name="e">The event arguments.</param>
-        protected override void OnClosing(CancelEventArgs e)
-        {
-            if (DataContext is INotifyDataErrorInfo nde)
+		/// <inheritdoc/>
+		/// <remarks>
+		/// Also calls <see cref="EndEdit"/> or <see cref="CancelEdit"/> methods depending on <see cref="System.Windows.Window.DialogResult"/> value
+		/// </remarks> 
+		protected override void OnClosing(CancelEventArgs e)
+		{
+			base.OnClosing(e);
+
+            if (!e.Cancel)
             {
-                nde.ErrorsChanged -= DataErrorsChanged; ;
-            }
-        }
+                if (this.DialogResult == true)
+                {
+                    this.EndEdit();
+                }
+                else
+                {
+                    this.CancelEdit();
+                }
+
+				if (DataContext is INotifyDataErrorInfo nde)
+				{
+                    nde.ErrorsChanged -= DataErrorsChanged;
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		protected override void OnClosed(EventArgs e)
+		{
+			base.OnClosed(e);
+
+			this.isClosedAlready_ButtonClickScope = true;
+		}
 
         /// <summary>
         /// Handles the DataErrorsChanged event to update the state of the data error aware buttons.

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
@@ -300,7 +300,8 @@ namespace PropertyTools.Wpf
 			
 			this.DialogResult = true;  // also will call Close() method when DialogResult != true
 
-			if (!this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
+			if (this.DialogResult == true  // check if Closing event was not cancelled.
+                && !this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
             {
                 this.Close();
             }

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
@@ -9,322 +9,322 @@
 
 namespace PropertyTools.Wpf
 {
-	using System;
-	using System.Collections.Generic;
-	using System.ComponentModel;
-	using System.Diagnostics;
-	using System.Linq;
-	using System.Reflection;
-	using System.Windows;
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
+    using System.Windows;
 
-	/// <summary>
-	/// Represents a property editing dialog.
-	/// </summary>
-	public partial class PropertyDialog : Window
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PropertyDialog" /> class.
-		/// </summary>
-		public PropertyDialog()
-		{
-			this.InitializeComponent();
-			this.MaxWidth = SystemParameters.PrimaryScreenWidth * 0.9;
-			this.MaxHeight = SystemParameters.PrimaryScreenHeight * 0.9;
-			this.ApplyButton.Visibility = Visibility.Collapsed;
-			this.CloseButton.Visibility = Visibility.Collapsed;
-			this.HelpButton.Visibility = Visibility.Collapsed;
-			this.DataContextChanged += this.PropertyDialogDataContextChanged;
-		}
+    /// <summary>
+    /// Represents a property editing dialog.
+    /// </summary>
+    public partial class PropertyDialog : Window
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyDialog" /> class.
+        /// </summary>
+        public PropertyDialog()
+        {
+            this.InitializeComponent();
+            this.MaxWidth = SystemParameters.PrimaryScreenWidth * 0.9;
+            this.MaxHeight = SystemParameters.PrimaryScreenHeight * 0.9;
+            this.ApplyButton.Visibility = Visibility.Collapsed;
+            this.CloseButton.Visibility = Visibility.Collapsed;
+            this.HelpButton.Visibility = Visibility.Collapsed;
+            this.DataContextChanged += this.PropertyDialogDataContextChanged;
+        }
 
-		/// <summary>
-		/// Gets or sets a value indicating whether the apply button is visible.
-		/// </summary>
-		/// <value><c>true</c> if this instance can apply; otherwise, <c>false</c> .</value>
-		public bool CanApply
-		{
-			get
-			{
-				return this.ApplyButton.Visibility == Visibility.Visible;
-			}
+        /// <summary>
+        /// Gets or sets a value indicating whether the apply button is visible.
+        /// </summary>
+        /// <value><c>true</c> if this instance can apply; otherwise, <c>false</c> .</value>
+        public bool CanApply
+        {
+            get
+            {
+                return this.ApplyButton.Visibility == Visibility.Visible;
+            }
 
-			set
-			{
-				this.ApplyButton.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
-			}
-		}
+            set
+            {
+                this.ApplyButton.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+            }
+        }
 
-		/// <summary>
-		/// Gets the property control.
-		/// </summary>
-		/// <value>The property control.</value>
-		public PropertyGrid PropertyControl
-		{
-			get
-			{
-				return this.PropertyGrid1;
-			}
-		}
+        /// <summary>
+        /// Gets the property control.
+        /// </summary>
+        /// <value>The property control.</value>
+        public PropertyGrid PropertyControl
+        {
+            get
+            {
+                return this.PropertyGrid1;
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets a value indicating whether the OK button is data error aware.
-		/// </summary>
-		public bool OkButtonDataErrorAware { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether the OK button is data error aware.
+        /// </summary>
+        public bool OkButtonDataErrorAware { get; set; }
 
-		/// <summary>
-		/// Gets or sets a value indicating whether the Apply button is data error aware.
-		/// </summary>
-		public bool ApplyButtonDataErrorAware { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether the Apply button is data error aware.
+        /// </summary>
+        public bool ApplyButtonDataErrorAware { get; set; }
 
-		/// <summary>
-		/// This stores the current "copy" of the object.
-		/// If it is non-<c>null</c>, then we are in the middle of an
-		/// editable operation.
-		/// </summary>
-		/// <param name="obj">The object.</param>
-		/// <returns>
-		/// Clone of current object
-		/// </returns>
-		protected virtual Dictionary<string, object> GetFieldValues(object obj)
-		{
-			return
-				obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
-					pi => pi.CanRead && pi.GetIndexParameters().Length == 0).Select(
-						pi => new { Key = pi.Name, Value = pi.GetValue(obj, null) }).ToDictionary(
-							k => k.Key, k => k.Value);
-		}
+        /// <summary>
+        /// This stores the current "copy" of the object.
+        /// If it is non-<c>null</c>, then we are in the middle of an
+        /// editable operation.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <returns>
+        /// Clone of current object
+        /// </returns>
+        protected virtual Dictionary<string, object> GetFieldValues(object obj)
+        {
+            return
+                obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
+                    pi => pi.CanRead && pi.GetIndexParameters().Length == 0).Select(
+                        pi => new { Key = pi.Name, Value = pi.GetValue(obj, null) }).ToDictionary(
+                            k => k.Key, k => k.Value);
+        }
 
-		/// <summary>
-		/// This restores the state of the current object from the passed clone object.
-		/// </summary>
-		/// <param name="fieldValues">Object to restore state from</param>
-		/// <param name="obj"></param>
-		protected virtual void RestoreFieldValues(Dictionary<string, object> fieldValues, object obj)
-		{
-			foreach (var pi in
-				obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
-					pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
-			{
-				object value;
-				if (fieldValues.TryGetValue(pi.Name, out value))
-				{
-					pi.SetValue(obj, value, null);
-				}
-				else
-				{
-					Debug.WriteLine(
-						"Failed to restore property " + pi.Name
-						+ " from cloned values, property not found in Dictionary.");
-				}
-			}
-		}
+        /// <summary>
+        /// This restores the state of the current object from the passed clone object.
+        /// </summary>
+        /// <param name="fieldValues">Object to restore state from</param>
+        /// <param name="obj"></param>
+        protected virtual void RestoreFieldValues(Dictionary<string, object> fieldValues, object obj)
+        {
+            foreach (var pi in
+                obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
+                    pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
+            {
+                object value;
+                if (fieldValues.TryGetValue(pi.Name, out value))
+                {
+                    pi.SetValue(obj, value, null);
+                }
+                else
+                {
+                    Debug.WriteLine(
+                        "Failed to restore property " + pi.Name
+                        + " from cloned values, property not found in Dictionary.");
+                }
+            }
+        }
 
-		/// <summary>
-		/// Clones the object memberwise.
-		/// </summary>
-		/// <param name="src">The SRC.</param>
-		/// <returns>
-		/// The memberwise clone.
-		/// </returns>
-		private static object MemberwiseClone(object src)
-		{
-			var t = src.GetType();
-			var clone = Activator.CreateInstance(t);
-			foreach (var pi in
-				t.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
-					pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
-			{
-				pi.SetValue(clone, pi.GetValue(src, null), null);
-			}
+        /// <summary>
+        /// Clones the object memberwise.
+        /// </summary>
+        /// <param name="src">The SRC.</param>
+        /// <returns>
+        /// The memberwise clone.
+        /// </returns>
+        private static object MemberwiseClone(object src)
+        {
+            var t = src.GetType();
+            var clone = Activator.CreateInstance(t);
+            foreach (var pi in
+                t.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
+                    pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
+            {
+                pi.SetValue(clone, pi.GetValue(src, null), null);
+            }
 
-			return clone;
-		}
+            return clone;
+        }
 
-		/// <summary>
-		/// The apply button click.
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The e.</param>
-		private void ApplyButtonClick(object sender, RoutedEventArgs e)
-		{
-			this.CommitChanges();
-		}
+        /// <summary>
+        /// The apply button click.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The e.</param>
+        private void ApplyButtonClick(object sender, RoutedEventArgs e)
+        {
+            this.CommitChanges();
+        }
 
-		/// <summary>
-		/// Begins the edit.
-		/// </summary>
-		private void BeginEdit()
-		{
-			var editableDataContext = this.DataContext as IEditableObject;
+        /// <summary>
+        /// Begins the edit.
+        /// </summary>
+        private void BeginEdit()
+        {
+            var editableDataContext = this.DataContext as IEditableObject;
 
-			if (editableDataContext != null)
-			{
-				editableDataContext.BeginEdit();
-			}
-			else
-			{
-				this.PropertyControl.DataContext = MemberwiseClone(this.DataContext);
-			}
+            if (editableDataContext != null)
+            {
+                editableDataContext.BeginEdit();
+            }
+            else
+            {
+                this.PropertyControl.DataContext = MemberwiseClone(this.DataContext);
+            }
 
-			if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
-			{
-				nde.ErrorsChanged -= DataErrorsChanged;
-				nde.ErrorsChanged += DataErrorsChanged;
-				this.SetDataErrorAwareButtons();
-			}
-		}
+            if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
+            {
+                nde.ErrorsChanged -= DataErrorsChanged;
+                nde.ErrorsChanged += DataErrorsChanged;
+                this.SetDataErrorAwareButtons();
+            }
+        }
 
-		/// <summary>
-		/// Cancels the edit.
-		/// </summary>
-		private void CancelEdit()
-		{
-			var editableDataContext = this.DataContext as IEditableObject;
+        /// <summary>
+        /// Cancels the edit.
+        /// </summary>
+        private void CancelEdit()
+        {
+            var editableDataContext = this.DataContext as IEditableObject;
 
-			if (editableDataContext != null)
-			{
-				editableDataContext.CancelEdit();
-			}
-		}
+            if (editableDataContext != null)
+            {
+                editableDataContext.CancelEdit();
+            }
+        }
 
-		/// <summary>
-		/// Commits the changes.
-		/// </summary>
-		private void CommitChanges()
-		{
-			// copy changes from cloned object (stored in PropertyEditor.DataContext)
-			// to the original object (stored in DataContext)
-			var clone = this.PropertyControl.DataContext;
-			if (clone == null)
-			{
-				return;
-			}
+        /// <summary>
+        /// Commits the changes.
+        /// </summary>
+        private void CommitChanges()
+        {
+            // copy changes from cloned object (stored in PropertyEditor.DataContext)
+            // to the original object (stored in DataContext)
+            var clone = this.PropertyControl.DataContext;
+            if (clone == null)
+            {
+                return;
+            }
 
-			foreach (var pi in
-				clone.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).
-					Where(pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
-			{
-				var newValue = pi.GetValue(clone, null);
-				var oldValue = pi.GetValue(this.DataContext, null);
+            foreach (var pi in
+                clone.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).
+                    Where(pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
+            {
+                var newValue = pi.GetValue(clone, null);
+                var oldValue = pi.GetValue(this.DataContext, null);
 
-				if (!object.Equals(oldValue, newValue))
-				{
-					pi.SetValue(this.DataContext, newValue, null);
-				}
-			}
-		}
+                if (!object.Equals(oldValue, newValue))
+                {
+                    pi.SetValue(this.DataContext, newValue, null);
+                }
+            }
+        }
 
-		/// <summary>
-		/// Ends the edit.
-		/// </summary>
-		private void EndEdit()
-		{
-			var editableDataContext = this.DataContext as IEditableObject;
+        /// <summary>
+        /// Ends the edit.
+        /// </summary>
+        private void EndEdit()
+        {
+            var editableDataContext = this.DataContext as IEditableObject;
 
-			if (editableDataContext != null)
-			{
-				editableDataContext.EndEdit();
-			}
-			else
-			{
-				this.CommitChanges();
-			}
-		}
+            if (editableDataContext != null)
+            {
+                editableDataContext.EndEdit();
+            }
+            else
+            {
+                this.CommitChanges();
+            }
+        }
 
-		/// <summary>
-		/// Handles the Click event of the Close button.
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The event arguments.</param>
-		private void CloseButtonClick(object sender, RoutedEventArgs e)
-		{
-			this.Close();
-		}
+        /// <summary>
+        /// Handles the Click event of the Close button.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void CloseButtonClick(object sender, RoutedEventArgs e)
+        {
+            this.Close();
+        }
 
-		/// <summary>
-		/// Handles the Click event of the Help button.
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The event arguments.</param>
-		private void HelpButtonClick(object sender, RoutedEventArgs e)
-		{
-		}
+        /// <summary>
+        /// Handles the Click event of the Help button.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void HelpButtonClick(object sender, RoutedEventArgs e)
+        {
+        }
 
-		/// <summary>
-		/// Handles the Click event of the Ok button.
-		/// </summary>        
-		/// <param name="sender">The sender.</param>        
-		/// <param name="e">The event arguments.</param>
-		/// <remarks>
-		/// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
-		/// </remarks>
-		private void OkButtonClick(object sender, RoutedEventArgs e)
-		{
-			this.DialogResult = true;  // also will call Close()
-									   // Window.Close operation may be interrupted in OnClosing event handler
-		}
+        /// <summary>
+        /// Handles the Click event of the Ok button.
+        /// </summary>        
+        /// <param name="sender">The sender.</param>        
+        /// <param name="e">The event arguments.</param>
+        /// <remarks>
+        /// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
+        /// </remarks>
+        private void OkButtonClick(object sender, RoutedEventArgs e)
+        {
+            this.DialogResult = true;  // also will call Close()
+                                       // Window.Close operation may be interrupted in OnClosing event handler
+        }
 
-		/// <summary>
-		/// Handles the Changed event of the DataContext.
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The event arguments.</param>
-		private void PropertyDialogDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
-		{
-			this.BeginEdit();
-		}
+        /// <summary>
+        /// Handles the Changed event of the DataContext.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void PropertyDialogDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            this.BeginEdit();
+        }
 
-		/// <summary>
-		/// Handles the Closing event of the PropertyDialog control.
-		/// </summary>
-		/// <param name="e">The event arguments.</param>
-		protected override void OnClosing(CancelEventArgs e)
-		{
-			var pdcEventArgs = new PropertyDialogCancelEventArgs(
-				editingContext: this.PropertyControl.DataContext, 
-				dialogResult: this.DialogResult
-			);
-			base.OnClosing(pdcEventArgs);
-			e.Cancel = pdcEventArgs.Cancel;
+        /// <summary>
+        /// Handles the Closing event of the PropertyDialog control.
+        /// </summary>
+        /// <param name="e">The event arguments.</param>
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            var pdcEventArgs = new PropertyDialogCancelEventArgs(
+                editingContext: this.PropertyControl.DataContext,
+                dialogResult: this.DialogResult
+            );
+            base.OnClosing(pdcEventArgs);
+            e.Cancel = pdcEventArgs.Cancel;
 
-			if (!e.Cancel)
-			{
-				// diaglog will be closed -> finish editing before .Closed event is raised
-				if (this.DialogResult == true)
-				{
-					this.EndEdit();
-				}
-				else
-				{
-					this.CancelEdit();
-				}
+            if (!e.Cancel)
+            {
+                // diaglog will be closed -> finish editing before .Closed event is raised
+                if (this.DialogResult == true)
+                {
+                    this.EndEdit();
+                }
+                else
+                {
+                    this.CancelEdit();
+                }
 
-				if (DataContext is INotifyDataErrorInfo nde)
-				{
-					nde.ErrorsChanged -= DataErrorsChanged;
-				}
-			}
-		}
+                if (DataContext is INotifyDataErrorInfo nde)
+                {
+                    nde.ErrorsChanged -= DataErrorsChanged;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Handles the DataErrorsChanged event to update the state of the data error aware buttons.
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The event arguments.</param>
-		private void DataErrorsChanged(object sender, DataErrorsChangedEventArgs e)
-		{
-			SetDataErrorAwareButtons();
-		}
+        /// <summary>
+        /// Handles the DataErrorsChanged event to update the state of the data error aware buttons.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void DataErrorsChanged(object sender, DataErrorsChangedEventArgs e)
+        {
+            SetDataErrorAwareButtons();
+        }
 
-		/// <summary>
-		/// Sets the data error aware buttons based on the current state of the DataContext.
-		/// </summary>
-		private void SetDataErrorAwareButtons()
-		{
-			if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
-			{
-				this.OkButton.IsEnabled = !this.OkButtonDataErrorAware || !nde.HasErrors;
-				this.ApplyButton.IsEnabled = !this.ApplyButtonDataErrorAware || !nde.HasErrors;
-			}
-		}
-	}
+        /// <summary>
+        /// Sets the data error aware buttons based on the current state of the DataContext.
+        /// </summary>
+        private void SetDataErrorAwareButtons()
+        {
+            if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
+            {
+                this.OkButton.IsEnabled = !this.OkButtonDataErrorAware || !nde.HasErrors;
+                this.ApplyButton.IsEnabled = !this.ApplyButtonDataErrorAware || !nde.HasErrors;
+            }
+        }
+    }
 }

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
@@ -9,227 +9,227 @@
 
 namespace PropertyTools.Wpf
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Reflection;
-    using System.Windows;
+	using System;
+	using System.Collections.Generic;
+	using System.ComponentModel;
+	using System.Diagnostics;
+	using System.Linq;
+	using System.Reflection;
+	using System.Windows;
 
-    /// <summary>
-    /// Represents a property editing dialog.
-    /// </summary>
-    public partial class PropertyDialog : Window
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PropertyDialog" /> class.
-        /// </summary>
-        public PropertyDialog()
-        {
-            this.InitializeComponent();
-            this.MaxWidth = SystemParameters.PrimaryScreenWidth * 0.9;
-            this.MaxHeight = SystemParameters.PrimaryScreenHeight * 0.9;
-            this.ApplyButton.Visibility = Visibility.Collapsed;
-            this.CloseButton.Visibility = Visibility.Collapsed;
-            this.HelpButton.Visibility = Visibility.Collapsed;
-            this.DataContextChanged += this.PropertyDialogDataContextChanged;
-        }
+	/// <summary>
+	/// Represents a property editing dialog.
+	/// </summary>
+	public partial class PropertyDialog : Window
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PropertyDialog" /> class.
+		/// </summary>
+		public PropertyDialog()
+		{
+			this.InitializeComponent();
+			this.MaxWidth = SystemParameters.PrimaryScreenWidth * 0.9;
+			this.MaxHeight = SystemParameters.PrimaryScreenHeight * 0.9;
+			this.ApplyButton.Visibility = Visibility.Collapsed;
+			this.CloseButton.Visibility = Visibility.Collapsed;
+			this.HelpButton.Visibility = Visibility.Collapsed;
+			this.DataContextChanged += this.PropertyDialogDataContextChanged;
+		}
 
-        /// <summary>
-        /// Gets or sets a value indicating whether the apply button is visible.
-        /// </summary>
-        /// <value><c>true</c> if this instance can apply; otherwise, <c>false</c> .</value>
-        public bool CanApply
-        {
-            get
-            {
-                return this.ApplyButton.Visibility == Visibility.Visible;
-            }
+		/// <summary>
+		/// Gets or sets a value indicating whether the apply button is visible.
+		/// </summary>
+		/// <value><c>true</c> if this instance can apply; otherwise, <c>false</c> .</value>
+		public bool CanApply
+		{
+			get
+			{
+				return this.ApplyButton.Visibility == Visibility.Visible;
+			}
 
-            set
-            {
-                this.ApplyButton.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
-            }
-        }
+			set
+			{
+				this.ApplyButton.Visibility = value ? Visibility.Visible : Visibility.Collapsed;
+			}
+		}
 
-        /// <summary>
-        /// Gets the property control.
-        /// </summary>
-        /// <value>The property control.</value>
-        public PropertyGrid PropertyControl
-        {
-            get
-            {
-                return this.PropertyGrid1;
-            }
-        }
+		/// <summary>
+		/// Gets the property control.
+		/// </summary>
+		/// <value>The property control.</value>
+		public PropertyGrid PropertyControl
+		{
+			get
+			{
+				return this.PropertyGrid1;
+			}
+		}
 
-        /// <summary>
-        /// Gets or sets a value indicating whether the OK button is data error aware.
-        /// </summary>
-        public bool OkButtonDataErrorAware { get; set; }
+		/// <summary>
+		/// Gets or sets a value indicating whether the OK button is data error aware.
+		/// </summary>
+		public bool OkButtonDataErrorAware { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether the Apply button is data error aware.
-        /// </summary>
-        public bool ApplyButtonDataErrorAware { get; set; }
+		/// <summary>
+		/// Gets or sets a value indicating whether the Apply button is data error aware.
+		/// </summary>
+		public bool ApplyButtonDataErrorAware { get; set; }
 
-        /// <summary>
-        /// This stores the current "copy" of the object.
-        /// If it is non-<c>null</c>, then we are in the middle of an
-        /// editable operation.
-        /// </summary>
-        /// <param name="obj">The object.</param>
-        /// <returns>
-        /// Clone of current object
-        /// </returns>
-        protected virtual Dictionary<string, object> GetFieldValues(object obj)
-        {
-            return
-                obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
-                    pi => pi.CanRead && pi.GetIndexParameters().Length == 0).Select(
-                        pi => new { Key = pi.Name, Value = pi.GetValue(obj, null) }).ToDictionary(
-                            k => k.Key, k => k.Value);
-        }
+		/// <summary>
+		/// This stores the current "copy" of the object.
+		/// If it is non-<c>null</c>, then we are in the middle of an
+		/// editable operation.
+		/// </summary>
+		/// <param name="obj">The object.</param>
+		/// <returns>
+		/// Clone of current object
+		/// </returns>
+		protected virtual Dictionary<string, object> GetFieldValues(object obj)
+		{
+			return
+				obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
+					pi => pi.CanRead && pi.GetIndexParameters().Length == 0).Select(
+						pi => new { Key = pi.Name, Value = pi.GetValue(obj, null) }).ToDictionary(
+							k => k.Key, k => k.Value);
+		}
 
-        /// <summary>
-        /// This restores the state of the current object from the passed clone object.
-        /// </summary>
-        /// <param name="fieldValues">Object to restore state from</param>
-        /// <param name="obj"></param>
-        protected virtual void RestoreFieldValues(Dictionary<string, object> fieldValues, object obj)
-        {
-            foreach (var pi in
-                obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
-                    pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
-            {
-                object value;
-                if (fieldValues.TryGetValue(pi.Name, out value))
-                {
-                    pi.SetValue(obj, value, null);
-                }
-                else
-                {
-                    Debug.WriteLine(
-                        "Failed to restore property " + pi.Name
-                        + " from cloned values, property not found in Dictionary.");
-                }
-            }
-        }
+		/// <summary>
+		/// This restores the state of the current object from the passed clone object.
+		/// </summary>
+		/// <param name="fieldValues">Object to restore state from</param>
+		/// <param name="obj"></param>
+		protected virtual void RestoreFieldValues(Dictionary<string, object> fieldValues, object obj)
+		{
+			foreach (var pi in
+				obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
+					pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
+			{
+				object value;
+				if (fieldValues.TryGetValue(pi.Name, out value))
+				{
+					pi.SetValue(obj, value, null);
+				}
+				else
+				{
+					Debug.WriteLine(
+						"Failed to restore property " + pi.Name
+						+ " from cloned values, property not found in Dictionary.");
+				}
+			}
+		}
 
-        /// <summary>
-        /// Clones the object memberwise.
-        /// </summary>
-        /// <param name="src">The SRC.</param>
-        /// <returns>
-        /// The memberwise clone.
-        /// </returns>
-        private static object MemberwiseClone(object src)
-        {
-            var t = src.GetType();
-            var clone = Activator.CreateInstance(t);
-            foreach (var pi in
-                t.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
-                    pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
-            {
-                pi.SetValue(clone, pi.GetValue(src, null), null);
-            }
+		/// <summary>
+		/// Clones the object memberwise.
+		/// </summary>
+		/// <param name="src">The SRC.</param>
+		/// <returns>
+		/// The memberwise clone.
+		/// </returns>
+		private static object MemberwiseClone(object src)
+		{
+			var t = src.GetType();
+			var clone = Activator.CreateInstance(t);
+			foreach (var pi in
+				t.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(
+					pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
+			{
+				pi.SetValue(clone, pi.GetValue(src, null), null);
+			}
 
-            return clone;
-        }
+			return clone;
+		}
 
-        /// <summary>
-        /// The apply button click.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The e.</param>
-        private void ApplyButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.CommitChanges();
-        }
+		/// <summary>
+		/// The apply button click.
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The e.</param>
+		private void ApplyButtonClick(object sender, RoutedEventArgs e)
+		{
+			this.CommitChanges();
+		}
 
-        /// <summary>
-        /// Begins the edit.
-        /// </summary>
-        private void BeginEdit()
-        {
-            var editableDataContext = this.DataContext as IEditableObject;
+		/// <summary>
+		/// Begins the edit.
+		/// </summary>
+		private void BeginEdit()
+		{
+			var editableDataContext = this.DataContext as IEditableObject;
 
-            if (editableDataContext != null)
-            {
-                editableDataContext.BeginEdit();
-            }
-            else
-            {
-                this.PropertyControl.DataContext = MemberwiseClone(this.DataContext);
-            }
+			if (editableDataContext != null)
+			{
+				editableDataContext.BeginEdit();
+			}
+			else
+			{
+				this.PropertyControl.DataContext = MemberwiseClone(this.DataContext);
+			}
 
-            
-            if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
-            {
+
+			if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
+			{
 				nde.ErrorsChanged -= DataErrorsChanged;
 				nde.ErrorsChanged += DataErrorsChanged;
-                this.SetDataErrorAwareButtons();
-            }
-        }
+				this.SetDataErrorAwareButtons();
+			}
+		}
 
-        /// <summary>
-        /// Cancels the edit.
-        /// </summary>
-        private void CancelEdit()
-        {
-            var editableDataContext = this.DataContext as IEditableObject;
+		/// <summary>
+		/// Cancels the edit.
+		/// </summary>
+		private void CancelEdit()
+		{
+			var editableDataContext = this.DataContext as IEditableObject;
 
-            if (editableDataContext != null)
-            {
-                editableDataContext.CancelEdit();
-            }
-        }
+			if (editableDataContext != null)
+			{
+				editableDataContext.CancelEdit();
+			}
+		}
 
-        /// <summary>
-        /// Commits the changes.
-        /// </summary>
-        private void CommitChanges()
-        {
-            // copy changes from cloned object (stored in PropertyEditor.DataContext)
-            // to the original object (stored in DataContext)
-            var clone = this.PropertyControl.DataContext;
-            if (clone == null)
-            {
-                return;
-            }
+		/// <summary>
+		/// Commits the changes.
+		/// </summary>
+		private void CommitChanges()
+		{
+			// copy changes from cloned object (stored in PropertyEditor.DataContext)
+			// to the original object (stored in DataContext)
+			var clone = this.PropertyControl.DataContext;
+			if (clone == null)
+			{
+				return;
+			}
 
-            foreach (var pi in
-                clone.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).
-                    Where(pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
-            {
-                var newValue = pi.GetValue(clone, null);
-                var oldValue = pi.GetValue(this.DataContext, null);
+			foreach (var pi in
+				clone.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).
+					Where(pi => pi.CanWrite && pi.GetIndexParameters().Length == 0))
+			{
+				var newValue = pi.GetValue(clone, null);
+				var oldValue = pi.GetValue(this.DataContext, null);
 
-                if (!object.Equals(oldValue, newValue))
-                {
-                    pi.SetValue(this.DataContext, newValue, null);
-                }
-            }
-        }
+				if (!object.Equals(oldValue, newValue))
+				{
+					pi.SetValue(this.DataContext, newValue, null);
+				}
+			}
+		}
 
-        /// <summary>
-        /// Ends the edit.
-        /// </summary>
-        protected void EndEdit()
-        {
-            var editableDataContext = this.DataContext as IEditableObject;
+		/// <summary>
+		/// Ends the edit.
+		/// </summary>
+		protected void EndEdit()
+		{
+			var editableDataContext = this.DataContext as IEditableObject;
 
-            if (editableDataContext != null)
-            {
-                editableDataContext.EndEdit();
-            }
-            else
-            {
-                this.CommitChanges();
-            }
-        }
+			if (editableDataContext != null)
+			{
+				editableDataContext.EndEdit();
+			}
+			else
+			{
+				this.CommitChanges();
+			}
+		}
 
 		/// <summary>
 		/// Handles the Click event of the Cancel button.
@@ -240,7 +240,7 @@ namespace PropertyTools.Wpf
 		/// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
 		/// </remarks>
 		private void CancelButtonClick(object sender, RoutedEventArgs e)
-        {
+		{
 			this.isClosedAlready_ButtonClickScope = false; // reset flag
 
 			this.DialogResult = false; // also will call Close() method when DialogResult != false
@@ -249,31 +249,31 @@ namespace PropertyTools.Wpf
 			{
 				this.Close();
 			}
-        }
+		}
 
-        /// <summary>
-        /// Handles the Click event of the Close button.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The event arguments.</param>
-        private void CloseButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.Close();
-        }
+		/// <summary>
+		/// Handles the Click event of the Close button.
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The event arguments.</param>
+		private void CloseButtonClick(object sender, RoutedEventArgs e)
+		{
+			this.Close();
+		}
 
-        /// <summary>
-        /// Handles the Click event of the Help button.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The event arguments.</param>
-        private void HelpButtonClick(object sender, RoutedEventArgs e)
-        {
-        }
+		/// <summary>
+		/// Handles the Click event of the Help button.
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The event arguments.</param>
+		private void HelpButtonClick(object sender, RoutedEventArgs e)
+		{
+		}
 
 		/// <summary>
 		/// Flag determines whether or not dialog was closed already.<para/>
 		/// Suffix (scope) indicates that flag value must be checked only in 
-        /// <see cref="OkButtonClick(object, RoutedEventArgs)"/> and <see cref="CloseButtonClick(object, RoutedEventArgs)"/>. <para/>
+		/// <see cref="OkButtonClick(object, RoutedEventArgs)"/> and <see cref="CloseButtonClick(object, RoutedEventArgs)"/>. <para/>
 		/// Helps to prevent raising the <see cref="System.Windows.Window.Closed"/> event twice.
 		/// </summary>
 		/// <remarks>
@@ -287,20 +287,20 @@ namespace PropertyTools.Wpf
 		/// <param name="sender">The sender.</param>        
 		/// <param name="e">The event arguments.</param>
 		/// <remarks>
-        /// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
+		/// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
 		/// </remarks>
 		private void OkButtonClick(object sender, RoutedEventArgs e)
-        {
-            this.isClosedAlready_ButtonClickScope = false; // reset flag
-			
+		{
+			this.isClosedAlready_ButtonClickScope = false; // reset flag
+
 			this.DialogResult = true;  // also will call Close() method when DialogResult != true
 
 			if (this.DialogResult == true  // check if Closing event was not cancelled.
-                && !this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
-            {
-                this.Close();
-            }
-        }
+				&& !this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
+			{
+				this.Close();
+			}
+		}
 
 		/// <summary>
 		/// Handles the Changed event of the DataContext.
@@ -308,32 +308,32 @@ namespace PropertyTools.Wpf
 		/// <param name="sender">The sender.</param>
 		/// <param name="e">The event arguments.</param>
 		private void PropertyDialogDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            this.BeginEdit();
-        }
+		{
+			this.BeginEdit();
+		}
 
-        /// <summary>
-        /// Handles the Closing event of the PropertyDialog control.
-        /// </summary>
-        /// <param name="e">The event arguments.</param>
-        protected override void OnClosing(CancelEventArgs e)
-        {
-            base.OnClosing(e);
+		/// <summary>
+		/// Handles the Closing event of the PropertyDialog control.
+		/// </summary>
+		/// <param name="e">The event arguments.</param>
+		protected override void OnClosing(CancelEventArgs e)
+		{
+			base.OnClosing(e);
 
-            if (DataContext is INotifyDataErrorInfo nde)
-            {
-                if (this.DialogResult == true)
-                {
-                    this.EndEdit();
-                }
-                else
-                {
-                    this.CancelEdit();
-                }
+			if (!e.Cancel)
+			{
+				if (this.DialogResult == true)
+				{
+					this.EndEdit();
+				}
+				else
+				{
+					this.CancelEdit();
+				}
 
 				if (DataContext is INotifyDataErrorInfo nde)
 				{
-                    nde.ErrorsChanged -= DataErrorsChanged;
+					nde.ErrorsChanged -= DataErrorsChanged;
 				}
 			}
 		}
@@ -346,26 +346,26 @@ namespace PropertyTools.Wpf
 			this.isClosedAlready_ButtonClickScope = true;
 		}
 
-        /// <summary>
-        /// Handles the DataErrorsChanged event to update the state of the data error aware buttons.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The event arguments.</param>
-        private void DataErrorsChanged(object sender, DataErrorsChangedEventArgs e)
-        {
-            SetDataErrorAwareButtons();
-        }
+		/// <summary>
+		/// Handles the DataErrorsChanged event to update the state of the data error aware buttons.
+		/// </summary>
+		/// <param name="sender">The sender.</param>
+		/// <param name="e">The event arguments.</param>
+		private void DataErrorsChanged(object sender, DataErrorsChangedEventArgs e)
+		{
+			SetDataErrorAwareButtons();
+		}
 
-        /// <summary>
-        /// Sets the data error aware buttons based on the current state of the DataContext.
-        /// </summary>
-        private void SetDataErrorAwareButtons()
-        {
-            if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
-            {
-                this.OkButton.IsEnabled = !this.OkButtonDataErrorAware || !nde.HasErrors;
-                this.ApplyButton.IsEnabled = !this.ApplyButtonDataErrorAware || !nde.HasErrors;
-            }
-        }
-    }
+		/// <summary>
+		/// Sets the data error aware buttons based on the current state of the DataContext.
+		/// </summary>
+		private void SetDataErrorAwareButtons()
+		{
+			if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
+			{
+				this.OkButton.IsEnabled = !this.OkButtonDataErrorAware || !nde.HasErrors;
+				this.ApplyButton.IsEnabled = !this.ApplyButtonDataErrorAware || !nde.HasErrors;
+			}
+		}
+	}
 }

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
@@ -165,7 +165,6 @@ namespace PropertyTools.Wpf
 				this.PropertyControl.DataContext = MemberwiseClone(this.DataContext);
 			}
 
-
 			if (PropertyControl.DataContext is INotifyDataErrorInfo nde)
 			{
 				nde.ErrorsChanged -= DataErrorsChanged;
@@ -217,7 +216,7 @@ namespace PropertyTools.Wpf
 		/// <summary>
 		/// Ends the edit.
 		/// </summary>
-		protected void EndEdit()
+		private void EndEdit()
 		{
 			var editableDataContext = this.DataContext as IEditableObject;
 
@@ -251,17 +250,6 @@ namespace PropertyTools.Wpf
 		}
 
 		/// <summary>
-		/// Flag determines whether or not dialog was closed already.<para/>
-		/// Suffix (scope) indicates that flag value must be checked only in 
-		/// <see cref="OkButtonClick(object, RoutedEventArgs)"/> and <see cref="CloseButtonClick(object, RoutedEventArgs)"/>. <para/>
-		/// Helps to prevent raising the <see cref="System.Windows.Window.Closed"/> event twice.
-		/// </summary>
-		/// <remarks>
-		/// Flag must be set in <see cref="OnClosed(EventArgs)"/> only
-		/// </remarks>
-		private bool isClosedAlready;
-
-		/// <summary>
 		/// Handles the Click event of the Ok button.
 		/// </summary>        
 		/// <param name="sender">The sender.</param>        
@@ -271,15 +259,8 @@ namespace PropertyTools.Wpf
 		/// </remarks>
 		private void OkButtonClick(object sender, RoutedEventArgs e)
 		{
-			this.isClosedAlready = false; // reset flag
-
-			this.DialogResult = true;  // also will call Close() method when DialogResult != true
-
-			if (this.DialogResult == true  // check if Closing event was not cancelled.
-				&& !this.isClosedAlready) // prevent raising Close event twice
-			{
-				this.Close();
-			}
+			this.DialogResult = true;  // also will call Close()
+									   // Window.Close operation may be interrupted in OnClosing event handler
 		}
 
 		/// <summary>
@@ -298,10 +279,16 @@ namespace PropertyTools.Wpf
 		/// <param name="e">The event arguments.</param>
 		protected override void OnClosing(CancelEventArgs e)
 		{
-			base.OnClosing(e);
+			var pdcEventArgs = new PropertyDialogCancelEventArgs(
+				editingContext: this.PropertyControl.DataContext, 
+				dialogResult: this.DialogResult
+			);
+			base.OnClosing(pdcEventArgs);
+			e.Cancel = pdcEventArgs.Cancel;
 
 			if (!e.Cancel)
 			{
+				// diaglog will be closed -> finish editing before .Closed event is raised
 				if (this.DialogResult == true)
 				{
 					this.EndEdit();
@@ -316,14 +303,6 @@ namespace PropertyTools.Wpf
 					nde.ErrorsChanged -= DataErrorsChanged;
 				}
 			}
-		}
-
-		/// <inheritdoc/>
-		protected override void OnClosed(EventArgs e)
-		{
-			base.OnClosed(e);
-
-			this.isClosedAlready = true;
 		}
 
 		/// <summary>

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
@@ -232,26 +232,6 @@ namespace PropertyTools.Wpf
 		}
 
 		/// <summary>
-		/// Handles the Click event of the Cancel button.
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="e">The e.</param>
-		/// <remarks>
-		/// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method
-		/// </remarks>
-		private void CancelButtonClick(object sender, RoutedEventArgs e)
-		{
-			this.isClosedAlready_ButtonClickScope = false; // reset flag
-
-			this.DialogResult = false; // also will call Close() method when DialogResult != false
-
-			if (!this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
-			{
-				this.Close();
-			}
-		}
-
-		/// <summary>
 		/// Handles the Click event of the Close button.
 		/// </summary>
 		/// <param name="sender">The sender.</param>
@@ -279,7 +259,7 @@ namespace PropertyTools.Wpf
 		/// <remarks>
 		/// Flag must be set in <see cref="OnClosed(EventArgs)"/> only
 		/// </remarks>
-		private bool isClosedAlready_ButtonClickScope;
+		private bool isClosedAlready;
 
 		/// <summary>
 		/// Handles the Click event of the Ok button.
@@ -291,12 +271,12 @@ namespace PropertyTools.Wpf
 		/// </remarks>
 		private void OkButtonClick(object sender, RoutedEventArgs e)
 		{
-			this.isClosedAlready_ButtonClickScope = false; // reset flag
+			this.isClosedAlready = false; // reset flag
 
 			this.DialogResult = true;  // also will call Close() method when DialogResult != true
 
 			if (this.DialogResult == true  // check if Closing event was not cancelled.
-				&& !this.isClosedAlready_ButtonClickScope) // prevent raising Close event twice
+				&& !this.isClosedAlready) // prevent raising Close event twice
 			{
 				this.Close();
 			}
@@ -343,7 +323,7 @@ namespace PropertyTools.Wpf
 		{
 			base.OnClosed(e);
 
-			this.isClosedAlready_ButtonClickScope = true;
+			this.isClosedAlready = true;
 		}
 
 		/// <summary>

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialog.xaml.cs
@@ -251,8 +251,8 @@ namespace PropertyTools.Wpf
 
         /// <summary>
         /// Handles the Click event of the Ok button.
-        /// </summary>        
-        /// <param name="sender">The sender.</param>        
+        /// </summary>
+        /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
         /// <remarks>
         /// The <see cref="EndEdit"/> call has been moved into <see cref="OnClosing(CancelEventArgs)"/> method

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialogCancelEventArgs.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialogCancelEventArgs.cs
@@ -3,7 +3,7 @@
 //   Copyright (c) 2014 PropertyTools contributors
 // </copyright>
 // <summary>
-//   Represents a property editing dialog.
+//   Represents a custom CancelEventArgs for <see cref="PropertyDialog"/>'s Closing event
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -11,6 +11,9 @@ namespace PropertyTools.Wpf
 {
 	using System.ComponentModel;
 
+    /// <summary>
+    /// Represents a custom CancelEventArgs for <see cref="PropertyDialog"/>'s Closing event
+    /// </summary>
 	public class PropertyDialogCancelEventArgs : CancelEventArgs
 	{
 		public bool? DialogResult { get; }
@@ -20,13 +23,13 @@ namespace PropertyTools.Wpf
 		/// </summary>		
 		public object EditingContext { get; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="editingContext">
-		/// Instance currently being editing in PropertyDialog.
-		/// </param>
-		public PropertyDialogCancelEventArgs(object editingContext, bool? dialogResult)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyDialogCancelEventArgs" /> class.
+        /// </summary>
+        /// <param name="editingContext">
+        /// The instance currently being editing in PropertyDialog.
+        /// </param>
+        public PropertyDialogCancelEventArgs(object editingContext, bool? dialogResult)
 		{
 			this.EditingContext = editingContext;
 			this.DialogResult = dialogResult;

--- a/Source/PropertyTools.Wpf/Dialogs/PropertyDialogCancelEventArgs.cs
+++ b/Source/PropertyTools.Wpf/Dialogs/PropertyDialogCancelEventArgs.cs
@@ -1,0 +1,35 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PropertyDialogCancelEventArgs.cs" company="PropertyTools">
+//   Copyright (c) 2014 PropertyTools contributors
+// </copyright>
+// <summary>
+//   Represents a property editing dialog.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace PropertyTools.Wpf
+{
+	using System.ComponentModel;
+
+	public class PropertyDialogCancelEventArgs : CancelEventArgs
+	{
+		public bool? DialogResult { get; }
+
+		/// <summary>
+		/// Instance currently being editing in PropertyDialog.
+		/// </summary>		
+		public object EditingContext { get; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="editingContext">
+		/// Instance currently being editing in PropertyDialog.
+		/// </param>
+		public PropertyDialogCancelEventArgs(object editingContext, bool? dialogResult)
+		{
+			this.EditingContext = editingContext;
+			this.DialogResult = dialogResult;
+		}
+	}
+}

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
@@ -135,8 +135,6 @@ namespace PropertyTools.Wpf
 					tab.Groups.Add(group);
 				}
 
-				#region Set tab sort index
-
 				if (tab.TabIndex == null)
 				{
 					tab.TabIndex = pi.TabSortIndex;
@@ -149,10 +147,6 @@ namespace PropertyTools.Wpf
 					));
 				}
 
-				#endregion
-
-				#region Set group sort index
-
 				if (group.GroupSortIndex == null)
 				{
 					group.GroupSortIndex = pi.GroupSortIndex;
@@ -164,8 +158,6 @@ namespace PropertyTools.Wpf
 							group.GroupSortIndex, pi.GroupSortIndex, group.Name
 					));
 				}
-
-				#endregion
 
 				group.Properties.Add(pi);
 			}


### PR DESCRIPTION
#484

 - Raise `Closing `event in PropertyDialog. 
 - Prevent calling Closed event twice (removed `CancelButtonClick`, simplified `OkButtonClick `method)
 - Moved `EndEdit `and `CancelEdit `methods calls into `OnClosing `method.
 - introduced `PropertyDialogCancelEventArgs`
 - added examples with `PropertyDialogCancelEventArgs ` usage
 - removed empty `OnClosed `method.
