### PR TITLE
Restore FontFamily combobox SelectedValue  (closes #492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - DataGrid: Added `ClipboardSeparator` dependency property that controls the separator used by `Ctrl+Alt+C` (copy with headers). Defaults to the current culture's list separator (`CultureInfo.CurrentCulture.TextInfo.ListSeparator`). Can be set per-instance in XAML or overridden in a subclass #481
 
 ### Fixed
+- PropertyGrid: Fixed FontFamilySelector does not restore actual property value #492
 - PropertyDialog: Fixed Closing event not being raised by calling base.OnClosing(e) #484
 - PropertyDialog: Fixed `CommitChanges` not setting new value when original value is `null` #486
 - PropertyGrid: Fixed FillTab control not stretching to fill available space when HeaderPlacement is Above, including when the model implements IDataErrorInfo or INotifyDataErrorInfo #488

--- a/Source/PropertyTools.Wpf/Converters/FontFamilyConverter.cs
+++ b/Source/PropertyTools.Wpf/Converters/FontFamilyConverter.cs
@@ -43,8 +43,11 @@ namespace PropertyTools.Wpf
                 var name = value as string;
                 if (name != null)
                 {
-                    if (targetType == typeof(FontFamily))
-                    {
+                    if (targetType == typeof(FontFamily)                    
+                        || targetType == typeof(object) // since Selector.SelectedValueProperty dependency property has .PropertyType == typeof(object)
+														// see PropertyGridControlFactory.CreateFontFamilyControl() method
+					)
+					{
                         return new FontFamily(name);
                     }
 


### PR DESCRIPTION
Handled case when 'targetType' parameter in `FontFamilyConverter.Convert` method is 'System.Object' 
(since Selector.SelectedValueProperty dependency property has .PropertyType == typeof(object) )
												