### PR TITLE
introduce category tab and group sort index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Added
+- PropertyGrid: Added CategoryAttribute .TabSortIndex and .GroupSortIndex properties including CategoryAttributeOrderedExample that demonstates expicit ordering of tabs & groups  #494
 - GitHub Copilot: Added path-specific custom instructions for tests, examples, WPF controls, and core library to provide contextual guidance based on file types #475
 - DemoLauncher: Created centralized demo launcher application that discovers and launches all example windows from any assembly, with text/tag filtering, command-line support, and screenshot capture functionality #468
 - TreeListBoxDemo: Restructured to support multiple examples with a launcher window, added MultipleRootsExample demonstrating the fix for issue #282 #282

--- a/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CategoryAttributeOrderedExample.cs
+++ b/Source/Examples/PropertyGrid/PropertyGridDemo/Examples/CategoryAttributeOrderedExample.cs
@@ -1,0 +1,93 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedCategoryAttributeExample.cs" company="PropertyTools">
+//   Copyright (c) 2014 PropertyTools contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using PropertyTools.DataAnnotations;
+
+namespace ExampleLibrary
+{
+	/// <remarks>
+	/// Propertes (fields) represent roman numbers <seealso cref="https://en.wikipedia.org/wiki/Roman_numerals"/>
+	/// </remarks>
+	[PropertyGridExample]
+	public class CategoryAttributeOrderedExample : Example	
+    {
+		private int numberC = 100;
+		private int numberCC = 200;
+		private int numberCCC = 300;
+		private int numberCD = 400;
+
+		private int numberD = 500;
+		private int numberDC = 600;
+		private int numberDCC = 700;
+		private int numberDCCC = 800;
+
+		private int numberCM = 900;
+
+		private int numberX = 10;
+		private int numberL = 50;
+
+		#region Hundreds / D
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category D", tabSortIndex: 1, groupSortIndex: 1)]		
+		public int NumberD { get => this.numberD; set { this.numberD = value; this.RaisePropertyChanged(nameof(NumberD)); } }
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category D", tabSortIndex: 1, groupSortIndex: 1)]		
+		public int NumberDC { get => this.numberDC; set { this.numberDC = value; this.RaisePropertyChanged(nameof(NumberDC)); } }
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category D", tabSortIndex: 1, groupSortIndex: 1)]		
+		public int NumberDCC { get => this.numberDCC; set { this.numberDCC = value; this.RaisePropertyChanged(nameof(NumberDCC)); } }
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category D", tabSortIndex: 1, groupSortIndex: 1)]		
+		public int NumberDCCC { get => this.numberDCCC; set { this.numberDCCC = value; this.RaisePropertyChanged(nameof(NumberDCCC)); } }
+
+		#endregion
+
+		#region Hundreds / C
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category C", tabSortIndex: 1)]		
+		public int NumberC { get => this.numberC; set { this.numberC = value; this.RaisePropertyChanged(nameof(NumberC)); } }
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category C", tabSortIndex: 1)]		
+		public int NumberCC { get => this.numberCC; set { this.numberCC = value; this.RaisePropertyChanged(nameof(NumberCC)); } }
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category C", tabSortIndex: 1)]		
+		public int NumberCCC { get => this.numberCCC; set { this.numberCCC = value; this.RaisePropertyChanged(nameof(NumberCCC)); } }
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category C", tabSortIndex: 1)]		
+		public int NumberCD { get => this.numberCD; set { this.numberCD = value; this.RaisePropertyChanged(nameof(NumberCD)); } }
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Hundreds (Roman)|Category C", tabSortIndex: 1)]
+		public int NumberCM { get => this.numberCM; set { this.numberCM = value; this.RaisePropertyChanged(nameof(NumberCM)); } }
+
+		#endregion
+
+
+		#region Tens / L
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Tens (Roman)|Category L", 0, 1)]
+		public int NumberL { get => this.numberL; set { this.numberL = value; this.RaisePropertyChanged(nameof(NumberL)); } }
+
+		#endregion
+
+		#region Tens / X
+
+		[ReadOnly(true)]
+		[PropertyTools.DataAnnotations.Category("Tens (Roman)|Category X", 0, 0)]
+		public int NumberX { get => this.numberX; set { this.numberX = value; this.RaisePropertyChanged(nameof(NumberX)); } }
+
+		#endregion
+	}
+}

--- a/Source/PropertyTools.Wpf/PropertyGrid/Group.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/Group.cs
@@ -31,30 +31,45 @@ namespace PropertyTools.Wpf
         /// <value>The description.</value>
         public string Description { get; set; }
 
-        /// <summary>
-        /// Gets or sets the header.
-        /// </summary>
-        /// <value>The header.</value>
-        public string Header { get; set; }
+		/// <summary>
+		/// Gets or sets the header (localizable).
+		/// </summary>
+		/// <value>The header.</value>
+		public string Header { get; set; }
 
-        /// <summary>
-        /// Gets or sets the icon.
-        /// </summary>
-        /// <value>The icon.</value>
-        public ImageSource Icon { get; set; }
+		/// <summary>
+		/// Gets or sets the group identifier (non-localizable).
+		/// </summary>
+		/// <remarks>
+		/// May be used in resolving the <see cref="Icon"/> property value.
+		/// </remarks>
+		/// <value>The name.</value>
+		public string Name { get; set; }
+
+		/// <summary>
+		/// Gets or sets the icon.
+		/// </summary>
+		/// <value>The icon.</value>
+		public ImageSource Icon { get; set; }
 
         /// <summary>
         /// Gets the properties.
         /// </summary>
         public List<PropertyItem> Properties { get; private set; }
 
-        /// <summary>
-        /// The to string.
-        /// </summary>
-        /// <returns>
-        /// The to string.
-        /// </returns>
-        public override string ToString()
+		/// <summary>
+		/// Gets or sets the group sort index.
+		/// </summary>
+		/// <value>The group sort index.</value>
+		public uint? GroupSortIndex { get; set; }
+
+		/// <summary>
+		/// The to string.
+		/// </summary>
+		/// <returns>
+		/// The to string.
+		/// </returns>
+		public override string ToString()
         {
             return this.Header;
         }

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
@@ -9,342 +9,354 @@
 
 namespace PropertyTools.Wpf
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.ComponentModel.DataAnnotations;
-    using System.Globalization;
-    using System.Linq;
-    using System.Windows;
-    using System.Windows.Data;
+	using System;
+	using System.Collections;
+	using System.Collections.Generic;
+	using System.ComponentModel;
+	using System.ComponentModel.DataAnnotations;
+	using System.Globalization;
+	using System.Linq;
+	using System.Windows;
+	using System.Windows.Data;
 
     using PropertyTools.DataAnnotations;
     using PropertyTools.Wpf.Operators;
 
-    /// <summary>
-    /// Creates a model for the <see cref="PropertyGrid" /> control.
-    /// </summary>
-    public class PropertyGridOperator : DefaultLocalizableOperator, IPropertyGridOperator
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PropertyGridOperator" /> class.
-        /// </summary>
-        public PropertyGridOperator()
-        {
-            this.EnabledPattern = "Is{0}Enabled";
-            this.VisiblePattern = "Is{0}Visible";
-            this.OptionalPattern = "Use{0}";
-            this.ModifyCamelCaseDisplayNames = true;
-            this.InheritCategories = true;
-        }
+	/// <summary>
+	/// Creates a model for the <see cref="PropertyGrid" /> control.
+	/// </summary>
+	public class PropertyGridOperator : DefaultLocalizableOperator, IPropertyGridOperator
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PropertyGridOperator" /> class.
+		/// </summary>
+		public PropertyGridOperator()
+		{
+			this.EnabledPattern = "Is{0}Enabled";
+			this.VisiblePattern = "Is{0}Visible";
+			this.OptionalPattern = "Use{0}";
+			this.ModifyCamelCaseDisplayNames = true;
+			this.InheritCategories = true;
+		}
 
-        /// <summary>
-        /// Gets or sets the default name of the category.
-        /// </summary>
-        /// <value>The default name of the category.</value>
-        public string DefaultCategoryName { get; set; }
+		/// <summary>
+		/// Gets or sets the default name of the category.
+		/// </summary>
+		/// <value>The default name of the category.</value>
+		public string DefaultCategoryName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the default name of the tab.
-        /// </summary>
-        /// <value>The default name of the tab.</value>
-        public string DefaultTabName { get; set; }
+		/// <summary>
+		/// Gets or sets the default name of the tab.
+		/// </summary>
+		/// <value>The default name of the tab.</value>
+		public string DefaultTabName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the enabled pattern.
-        /// </summary>
-        /// <value>The enabled pattern.</value>
-        public string EnabledPattern { get; set; }
+		/// <summary>
+		/// Gets or sets the enabled pattern.
+		/// </summary>
+		/// <value>The enabled pattern.</value>
+		public string EnabledPattern { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether each property should inherit the category attribute from the property declared before.
-        /// </summary>
-        public bool InheritCategories { get; set; }
+		/// <summary>
+		/// Gets or sets a value indicating whether each property should inherit the category attribute from the property declared before.
+		/// </summary>
+		public bool InheritCategories { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether to add spaces at the camel bumps of the display names.
-        /// </summary>
-        /// <value><c>true</c> if display names should be modified; otherwise, <c>false</c> .</value>
-        public bool ModifyCamelCaseDisplayNames { get; set; }
+		/// <summary>
+		/// Gets or sets a value indicating whether to add spaces at the camel bumps of the display names.
+		/// </summary>
+		/// <value><c>true</c> if display names should be modified; otherwise, <c>false</c> .</value>
+		public bool ModifyCamelCaseDisplayNames { get; set; }
 
-        /// <summary>
-        /// Gets or sets the optional pattern.
-        /// </summary>
-        /// <value>The optional pattern.</value>
-        public string OptionalPattern { get; set; }
+		/// <summary>
+		/// Gets or sets the optional pattern.
+		/// </summary>
+		/// <value>The optional pattern.</value>
+		public string OptionalPattern { get; set; }
 
-        /// <summary>
-        /// Gets or sets the visible pattern.
-        /// </summary>
-        /// <value>The visible pattern.</value>
-        public string VisiblePattern { get; set; }
+		/// <summary>
+		/// Gets or sets the visible pattern.
+		/// </summary>
+		/// <value>The visible pattern.</value>
+		public string VisiblePattern { get; set; }
 
-        /// <summary>
-        /// Gets or sets the current category.
-        /// </summary>
-        /// <value>The current category.</value>
-        protected string CurrentCategory { get; set; }
+		/// <summary>
+		/// Gets or sets the current category.
+		/// </summary>
+		/// <value>The current category.</value>
+		protected string CurrentCategory { get; set; }
 
-        /// <summary>
-        /// Gets or sets the declaring type of the current category.
-        /// </summary>
-        /// <value>The type of the current category.</value>
-        protected Type CurrentCategoryDeclaringType { get; set; }
+		/// <summary>
+		/// Gets or sets the declaring type of the current category.
+		/// </summary>
+		/// <value>The type of the current category.</value>
+		protected Type CurrentCategoryDeclaringType { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type of the current component.
-        /// </summary>
-        /// <value>The type of the current component.</value>
-        /// <remarks>This is used to avoid that Category attributes are inherited from superclass to subclass.</remarks>
-        protected Type CurrentDeclaringType { get; set; }
+		/// <summary>
+		/// Gets or sets the type of the current component.
+		/// </summary>
+		/// <value>The type of the current component.</value>
+		/// <remarks>This is used to avoid that Category attributes are inherited from superclass to subclass.</remarks>
+		protected Type CurrentDeclaringType { get; set; }
 
-        /// <summary>
-        /// Creates the property model.
-        /// </summary>
-        /// <param name="instance">The instance.</param>
-        /// <param name="isEnumerable">if set to <c>true</c> [is enumerable].</param>
-        /// <param name="options">The options.</param>
-        /// <returns>
-        /// A list of <see cref="Tab" /> .
-        /// </returns>
-        public virtual IEnumerable<Tab> CreateModel(object instance, bool isEnumerable, IPropertyGridOptions options)
-        {
-            if (instance == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Creates the property model.
+		/// </summary>
+		/// <param name="instance">The instance.</param>
+		/// <param name="isEnumerable">if set to <c>true</c> [is enumerable].</param>
+		/// <param name="options">The options.</param>
+		/// <returns>
+		/// A sorted list of <see cref="Tab" /> .
+		/// </returns>
+		public virtual IEnumerable<Tab> CreateModel(object instance, bool isEnumerable, IPropertyGridOptions options)
+		{
+			if (instance == null)
+			{
+				return null;
+			}
 
-            this.Reset();
+			this.Reset();
 
-            var tabs = new Dictionary<string, Tab>();
-            foreach (var pi in this.CreatePropertyItems(instance, options).OrderBy(t => t.SortIndex))
-            {
-                var tabHeader = pi.Tab ?? string.Empty;
-                if (!tabs.ContainsKey(tabHeader))
-                {
-                    tabs.Add(tabHeader, new Tab { Header = pi.Tab });
-                }
+			var tabs = new Dictionary<string, Tab>();
+			foreach (var pi in this.CreatePropertyItems(instance, options).OrderBy(t => t.SortIndex))
+			{
+				var tabHeader = pi.Tab ?? string.Empty;
+				if (!tabs.ContainsKey(tabHeader))
+				{
+					tabs.Add(tabHeader, new Tab { Header = pi.Tab });
+				}
 
-                var tab = tabs[tabHeader];
-                var category = pi.Category;
-                var group = tab.Groups.FirstOrDefault(g => g.Header == category);
-                if (group == null)
-                {
-                    group = new Group { Header = pi.Category };
-                    tab.Groups.Add(group);
-                }
+				var tab = tabs[tabHeader];
+				var category = pi.Category;
+				var group = tab.Groups.FirstOrDefault(g => g.Header == category);
+				if (group == null)
+				{
+					group = new Group { Header = pi.Category };
+					tab.Groups.Add(group);
+				}
+				
+				if (tab.TabIndex == null)
+				{
+					tab.TabIndex = pi.TabIndex;
+				}
+				else if (pi.TabIndex != null && pi.TabIndex != tab.TabIndex)
+				{
+					throw new ApplicationException(
+						String.Format("Two or more different tab indecies ({0} and {1}) are set for same tab '{2}'.", 
+							tab.TabIndex, pi.TabIndex, tabHeader
+					));
+				}
 
-                group.Properties.Add(pi);
-            }
+				group.Properties.Add(pi);
+			}
 
-            return tabs.Values.ToList();
-        }
+			return tabs.Values.OrderBy(t => t.TabIndex ?? 0).ToList();
+		}
 
-        /// <summary>
-        /// Creates a property item.
-        /// </summary>
-        /// <param name="pd">The property descriptor.</param>
-        /// <param name="propertyDescriptors">The property descriptors.</param>
-        /// <param name="instance">The instance.</param>
-        /// <returns>
-        /// A property item.
-        /// </returns>
-        public virtual PropertyItem CreatePropertyItem(PropertyDescriptor pd, PropertyDescriptorCollection propertyDescriptors, object instance)
-        {
-            var pi = this.CreateCore(pd, propertyDescriptors);
-            this.SetProperties(pi, instance);
-            return pi;
-        }
+		/// <summary>
+		/// Creates a property item.
+		/// </summary>
+		/// <param name="pd">The property descriptor.</param>
+		/// <param name="propertyDescriptors">The property descriptors.</param>
+		/// <param name="instance">The instance.</param>
+		/// <returns>
+		/// A property item.
+		/// </returns>
+		public virtual PropertyItem CreatePropertyItem(PropertyDescriptor pd, PropertyDescriptorCollection propertyDescriptors, object instance)
+		{
+			var pi = this.CreateCore(pd, propertyDescriptors);
+			this.SetProperties(pi, instance);
+			return pi;
+		}
 
-        /// <summary>
-        /// Resets this factory.
-        /// </summary>
-        public void Reset()
-        {
-            this.CurrentCategory = null;
-            this.CurrentDeclaringType = null;
-            this.CurrentCategoryDeclaringType = null;
-        }
+		/// <summary>
+		/// Resets this factory.
+		/// </summary>
+		public void Reset()
+		{
+			this.CurrentCategory = null;
+			this.CurrentDeclaringType = null;
+			this.CurrentCategoryDeclaringType = null;
+		}
 
-        /// <summary>
-        /// Creates property items for all properties in the specified object.
-        /// </summary>
-        /// <param name="instance">The object instance.</param>
-        /// <param name="options">The options.</param>
-        /// <returns>
-        /// Enumeration of PropertyItem.
-        /// </returns>
-        protected virtual IEnumerable<PropertyItem> CreatePropertyItems(object instance, IPropertyGridOptions options)
-        {
-            var properties = this.GetPropertyCollection(instance);
-            foreach (var pd in this.GetVisibleProperties(properties, instance, options))
-            {
-                yield return this.CreatePropertyItem(pd, properties, instance);
-            }
-        }
+		/// <summary>
+		/// Creates property items for all properties in the specified object.
+		/// </summary>
+		/// <param name="instance">The object instance.</param>
+		/// <param name="options">The options.</param>
+		/// <returns>
+		/// Enumeration of PropertyItem.
+		/// </returns>
+		protected virtual IEnumerable<PropertyItem> CreatePropertyItems(object instance, IPropertyGridOptions options)
+		{
+			var properties = this.GetPropertyCollection(instance);
+			foreach (var pd in this.GetVisibleProperties(properties, instance, options))
+			{
+				yield return this.CreatePropertyItem(pd, properties, instance);
+			}
+		}
 
-        /// <summary>
-        /// Gets the property descriptor collection for the specified object.
-        /// </summary>
-        /// <param name="instance">The object instance.</param>
-        /// <returns>The property collection</returns>
-        protected virtual PropertyDescriptorCollection GetPropertyCollection(object instance)
-        {
-            var instanceType = instance.GetType();
+		/// <summary>
+		/// Gets the property descriptor collection for the specified object.
+		/// </summary>
+		/// <param name="instance">The object instance.</param>
+		/// <returns>The property collection</returns>
+		protected virtual PropertyDescriptorCollection GetPropertyCollection(object instance)
+		{
+			var instanceType = instance.GetType();
 
-            // check if the MetadataTypeAttribute is set
-            var metadataTypeAttribute = instanceType.GetCustomAttributes(typeof(MetadataTypeAttribute), true)
-                                     .OfType<MetadataTypeAttribute>().FirstOrDefault();
-            PropertyDescriptorCollection properties;
-            if (metadataTypeAttribute != null)
-            {
-                // use the metadata type for reflection
-                instanceType = metadataTypeAttribute.MetadataClassType;
-                properties = TypeDescriptor.GetProperties(instanceType);
-            }
-            else
-            {
-                properties = TypeDescriptor.GetProperties(instance);
-            }
+			// check if the MetadataTypeAttribute is set
+			var metadataTypeAttribute = instanceType.GetCustomAttributes(typeof(MetadataTypeAttribute), true)
+									 .OfType<MetadataTypeAttribute>().FirstOrDefault();
+			PropertyDescriptorCollection properties;
+			if (metadataTypeAttribute != null)
+			{
+				// use the metadata type for reflection
+				instanceType = metadataTypeAttribute.MetadataClassType;
+				properties = TypeDescriptor.GetProperties(instanceType);
+			}
+			else
+			{
+				properties = TypeDescriptor.GetProperties(instance);
+			}
 
-            return properties;
-        }
+			return properties;
+		}
 
-        /// <summary>
-        /// Gets the visible properties from the specified property descriptor collection.
-        /// </summary>
-        /// <param name="properties">The property descriptor collection.</param>
-        /// <param name="instance">The object instance.</param>
-        /// <param name="options">The options.</param>
-        /// <returns>A sequence of property descriptors.</returns>
-        protected IEnumerable<PropertyDescriptor> GetVisibleProperties(PropertyDescriptorCollection properties, object instance, IPropertyGridOptions options)
-        {
-            var instanceType = instance.GetType();
+		/// <summary>
+		/// Gets the visible properties from the specified property descriptor collection.
+		/// </summary>
+		/// <param name="properties">The property descriptor collection.</param>
+		/// <param name="instance">The object instance.</param>
+		/// <param name="options">The options.</param>
+		/// <returns>A sequence of property descriptors.</returns>
+		protected IEnumerable<PropertyDescriptor> GetVisibleProperties(PropertyDescriptorCollection properties, object instance, IPropertyGridOptions options)
+		{
+			var instanceType = instance.GetType();
 
-            foreach (PropertyDescriptor pd in this.GetBrowsableProperties(properties))
-            {
-                if (options.ShowDeclaredOnly && pd.ComponentType != instanceType)
-                {
-                    continue;
-                }
+			foreach (PropertyDescriptor pd in this.GetBrowsableProperties(properties))
+			{
+				if (options.ShowDeclaredOnly && pd.ComponentType != instanceType)
+				{
+					continue;
+				}
 
-                // Read-only properties
-                if (!options.ShowReadOnlyProperties && pd.IsReadOnly())
-                {
-                    continue;
-                }
+				// Read-only properties
+				if (!options.ShowReadOnlyProperties && pd.IsReadOnly())
+				{
+					continue;
+				}
 
-                // If RequiredAttribute is set, skip properties that don't have the given attribute
-                if (options.RequiredAttribute != null && pd.GetFirstAttributeOrDefault(options.RequiredAttribute) == null)
-                {
-                    continue;
-                }
+				// If RequiredAttribute is set, skip properties that don't have the given attribute
+				if (options.RequiredAttribute != null && pd.GetFirstAttributeOrDefault(options.RequiredAttribute) == null)
+				{
+					continue;
+				}
 
-                yield return pd;
-            }
-        }
+				yield return pd;
+			}
+		}
 
-        /// <summary>
-        /// Gets the visible properties from the specified property descriptor collection.
-        /// </summary>
-        /// <param name="properties">The property descriptor collection.</param>
-        /// <returns>A sequence of property descriptors.</returns>
-        protected IEnumerable<PropertyDescriptor> GetBrowsableProperties(PropertyDescriptorCollection properties)
-        {
-            bool justTrue = AreBrowsableAttributesJustTrue(properties);
+		/// <summary>
+		/// Gets the visible properties from the specified property descriptor collection.
+		/// </summary>
+		/// <param name="properties">The property descriptor collection.</param>
+		/// <returns>A sequence of property descriptors.</returns>
+		protected IEnumerable<PropertyDescriptor> GetBrowsableProperties(PropertyDescriptorCollection properties)
+		{
+			bool justTrue = AreBrowsableAttributesJustTrue(properties);
 
-            foreach (PropertyDescriptor pd in properties)
-            {
-                var portableBrowsableAttribute = pd.GetFirstAttributeOrDefault<DataAnnotations.BrowsableAttribute>();
-                var systemBrowsableAttribute = pd.GetFirstAttributeOrDefault<System.ComponentModel.BrowsableAttribute>();
+			foreach (PropertyDescriptor pd in properties)
+			{
+				var portableBrowsableAttribute = pd.GetFirstAttributeOrDefault<DataAnnotations.BrowsableAttribute>();
+				var systemBrowsableAttribute = pd.GetFirstAttributeOrDefault<System.ComponentModel.BrowsableAttribute>();
 
-                // If all BrowsableAttributes in the properties are set to true, the default will be changed to false, e.g. you need to opt-in.
-                if (justTrue)
-                {
-                    // Skip properties not marked with [Browsable()]
-                    if (portableBrowsableAttribute == null && systemBrowsableAttribute == null)
-                    {
-                        continue;
-                    }
+				// If all BrowsableAttributes in the properties are set to true, the default will be changed to false, e.g. you need to opt-in.
+				if (justTrue)
+				{
+					// Skip properties not marked with [Browsable()]
+					if (portableBrowsableAttribute == null && systemBrowsableAttribute == null)
+					{
+						continue;
+					}
 
-                    // Skip properties not marked with [Browsable(true)]
-                    if (portableBrowsableAttribute != null && !portableBrowsableAttribute.Browsable)
-                    {
-                        continue;
-                    }
+					// Skip properties not marked with [Browsable(true)]
+					if (portableBrowsableAttribute != null && !portableBrowsableAttribute.Browsable)
+					{
+						continue;
+					}
 
-                    // Skip properties not marked with [Browsable(true)]
-                    if (systemBrowsableAttribute != null && !systemBrowsableAttribute.Browsable)
-                    {
-                        continue;
-                    }
-                }
-                // if any BrowsableAttribute in the properties are set to false, the default is true, e.g. you need to opt-out.
-                else
-                {
-                    // Skip properties marked with [PropertyTools.DataAnnotations.Browsable(false)]
-                    if (portableBrowsableAttribute != null && !portableBrowsableAttribute.Browsable)
-                    {
-                        continue;
-                    }
+					// Skip properties not marked with [Browsable(true)]
+					if (systemBrowsableAttribute != null && !systemBrowsableAttribute.Browsable)
+					{
+						continue;
+					}
+				}
+				// if any BrowsableAttribute in the properties are set to false, the default is true, e.g. you need to opt-out.
+				else
+				{
+					// Skip properties marked with [PropertyTools.DataAnnotations.Browsable(false)]
+					if (portableBrowsableAttribute != null && !portableBrowsableAttribute.Browsable)
+					{
+						continue;
+					}
 
-                    // Skip properties marked with [System.ComponentModel.Browsable(false)]
-                    if (!pd.IsBrowsable)
-                    {
-                        continue;
-                    }
-                }
+					// Skip properties marked with [System.ComponentModel.Browsable(false)]
+					if (!pd.IsBrowsable)
+					{
+						continue;
+					}
+				}
 
-                yield return pd;
-            }
-        }
+				yield return pd;
+			}
+		}
 
-        /// <summary>
-        /// Iterates over <see cref="PropertyDescriptorCollection"/> and determines whether the value of <see cref="System.ComponentModel.BrowsableAttribute"/>
-        /// or <see cref="DataAnnotations.BrowsableAttribute"/>, for those <see cref="PropertyDescriptor"/>s with such Attributes, is exclusively <see cref="true"/>
-        /// </summary>
-        /// <param name="propertyDescriptors">The collection of property descriptors.</param>
-        /// <returns>
-        /// A boolean
-        /// </returns>
-        protected bool AreBrowsableAttributesJustTrue(PropertyDescriptorCollection propertyDescriptors)
-        {
-            var attributes = propertyDescriptors.OfType<PropertyDescriptor>()
-              .Select(pd => Tuple.Create(pd.GetFirstAttributeOrDefault<DataAnnotations.BrowsableAttribute>(), pd.GetFirstAttributeOrDefault<System.ComponentModel.BrowsableAttribute>()))
-              .ToArray();
+		/// <summary>
+		/// Iterates over <see cref="PropertyDescriptorCollection"/> and determines whether the value of <see cref="System.ComponentModel.BrowsableAttribute"/>
+		/// or <see cref="DataAnnotations.BrowsableAttribute"/>, for those <see cref="PropertyDescriptor"/>s with such Attributes, is exclusively <see cref="true"/>
+		/// </summary>
+		/// <param name="propertyDescriptors">The collection of property descriptors.</param>
+		/// <returns>
+		/// A boolean
+		/// </returns>
+		protected bool AreBrowsableAttributesJustTrue(PropertyDescriptorCollection propertyDescriptors)
+		{
+			var attributes = propertyDescriptors.OfType<PropertyDescriptor>()
+			  .Select(pd => Tuple.Create(pd.GetFirstAttributeOrDefault<DataAnnotations.BrowsableAttribute>(), pd.GetFirstAttributeOrDefault<System.ComponentModel.BrowsableAttribute>()))
+			  .ToArray();
 
-            bool isAnyFalse = attributes.Any(a => (a.Item1 != null && a.Item1.Browsable == false) || (a.Item2 != null && a.Item2.Browsable == false));
-            bool isAnyTrue = attributes.Any(a => (a.Item1 != null && a.Item1.Browsable) || (a.Item2 != null && a.Item2.Browsable));
+			bool isAnyFalse = attributes.Any(a => (a.Item1 != null && a.Item1.Browsable == false) || (a.Item2 != null && a.Item2.Browsable == false));
+			bool isAnyTrue = attributes.Any(a => (a.Item1 != null && a.Item1.Browsable) || (a.Item2 != null && a.Item2.Browsable));
 
-            return isAnyTrue && !isAnyFalse;
-        }
+			return isAnyTrue && !isAnyFalse;
+		}
 
-        /// <summary>
-        /// Creates the property item instance.
-        /// </summary>
-        /// <param name="pd">The property descriptor.</param>
-        /// <param name="propertyDescriptors">The collection of property descriptors.</param>
-        /// <returns>
-        /// A property item.
-        /// </returns>
-        protected virtual PropertyItem CreateCore(PropertyDescriptor pd, PropertyDescriptorCollection propertyDescriptors)
-        {
-            return new PropertyItem(pd, propertyDescriptors);
-        }
+		/// <summary>
+		/// Creates the property item instance.
+		/// </summary>
+		/// <param name="pd">The property descriptor.</param>
+		/// <param name="propertyDescriptors">The collection of property descriptors.</param>
+		/// <returns>
+		/// A property item.
+		/// </returns>
+		protected virtual PropertyItem CreateCore(PropertyDescriptor pd, PropertyDescriptorCollection propertyDescriptors)
+		{
+			return new PropertyItem(pd, propertyDescriptors);
+		}
 
-        /// <summary>
-        /// Gets the category for the specified property.
-        /// </summary>
-        /// <param name="pd">The property descriptor.</param>
-        /// <param name="declaringType">The declaring type.</param>
-        /// <returns>
-        /// A category string.
-        /// </returns>
-        protected virtual string GetCategory(PropertyDescriptor pd, Type declaringType)
-        {
-            return pd.GetCategory();
-        }
+		/// <summary>
+		/// Gets the category for the specified property.
+		/// </summary>
+		/// <param name="pd">The property descriptor.</param>
+		/// <param name="declaringType">The declaring type.</param>
+		/// <returns>
+		/// A category string.
+		/// </returns>
+		protected virtual string GetCategory(PropertyDescriptor pd, Type declaringType)
+		{
+			return pd.GetCategory();
+		}
 
         /// <summary>
         /// Gets the description for the specified property.

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyGridOperator.cs
@@ -131,26 +131,49 @@ namespace PropertyTools.Wpf
 				var group = tab.Groups.FirstOrDefault(g => g.Header == category);
 				if (group == null)
 				{
-					group = new Group { Header = pi.Category };
+					group = new Group { Header = pi.Category, Name = pi.CategoryIdentifier };
 					tab.Groups.Add(group);
 				}
-				
+
+				#region Set tab sort index
+
 				if (tab.TabIndex == null)
 				{
-					tab.TabIndex = pi.TabIndex;
+					tab.TabIndex = pi.TabSortIndex;
 				}
-				else if (pi.TabIndex != null && pi.TabIndex != tab.TabIndex)
+				else if (pi.TabSortIndex != null && pi.TabSortIndex != tab.TabIndex)
 				{
 					throw new ApplicationException(
-						String.Format("Two or more different tab indecies ({0} and {1}) are set for same tab '{2}'.", 
-							tab.TabIndex, pi.TabIndex, tabHeader
+						String.Format("Two or more different tab indecies ({0} and {1}) are set for same tab '{2}'.",
+							tab.TabIndex, pi.TabSortIndex, tabHeader
 					));
 				}
+
+				#endregion
+
+				#region Set group sort index
+
+				if (group.GroupSortIndex == null)
+				{
+					group.GroupSortIndex = pi.GroupSortIndex;
+				}
+				else if (pi.GroupSortIndex != null && pi.GroupSortIndex != group.GroupSortIndex)
+				{
+					throw new ApplicationException(
+						String.Format("Two or more different group indecies ({0} and {1}) are set for same group '{2}'.",
+							group.GroupSortIndex, pi.GroupSortIndex, group.Name
+					));
+				}
+
+				#endregion
 
 				group.Properties.Add(pi);
 			}
 
-			return tabs.Values.OrderBy(t => t.TabIndex ?? 0).ToList();
+			return tabs.Values
+				.OrderBy(t => t.TabIndex ?? 0) // sorting tabs
+				.Select(t => t.SortGroups()) // sorting groups inside tab
+				.ToList();
 		}
 
 		/// <summary>
@@ -455,8 +478,14 @@ namespace PropertyTools.Wpf
             var displayName = this.GetDisplayName(pi.Descriptor, declaringType);
             var description = this.GetDescription(pi.Descriptor, declaringType);
 
-            // Localize the strings
-            pi.DisplayName = this.GetLocalizedString(displayName, declaringType);
+			pi.CategoryIdentifier = categoryName;
+			
+            // set tab/group sort index
+			pi.TabSortIndex = ca2?.TabSortIndex;
+			pi.GroupSortIndex = ca2?.GroupSortIndex;
+
+			// Localize the strings
+			pi.DisplayName = this.GetLocalizedString(displayName, declaringType);
             pi.Description = this.GetLocalizedDescription(description, declaringType);
             pi.Category = this.GetLocalizedString(categoryName, this.CurrentCategoryDeclaringType);
             pi.Tab = this.GetLocalizedString(tabName, this.CurrentCategoryDeclaringType);
@@ -859,4 +888,7 @@ namespace PropertyTools.Wpf
             }
         }
     }
+
+		
+
 }

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyItem.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyItem.cs
@@ -533,11 +533,17 @@ namespace PropertyTools.Wpf
         /// <value>The tab.</value>
         public string Tab { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text wrapping.
-        /// </summary>
-        /// <value>The text wrapping.</value>
-        public TextWrapping TextWrapping { get; set; }
+		/// <summary>
+		/// Gets or sets the tab sort index.
+		/// </summary>
+		/// <value>The tab.</value>
+		public uint? TabIndex { get; set; }
+
+		/// <summary>
+		/// Gets or sets the text wrapping.
+		/// </summary>
+		/// <value>The text wrapping.</value>
+		public TextWrapping TextWrapping { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the property should use radio buttons.

--- a/Source/PropertyTools.Wpf/PropertyGrid/PropertyItem.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/PropertyItem.cs
@@ -101,17 +101,23 @@ namespace PropertyTools.Wpf
         /// </value>
         public int IndentationLevel { get; set; }
 
-        /// <summary>
-        /// Gets or sets the category.
-        /// </summary>
-        /// <value>The category.</value>
-        public string Category { get; set; }
+		/// <summary>
+		/// Gets or sets the category (localizable).
+		/// </summary>
+		/// <value>The category.</value>
+		public string Category { get; set; }
 
-        /// <summary>
-        /// Gets the columns.
-        /// </summary>
-        /// <value>The columns.</value>
-        public List<ColumnDefinition> Columns { get; private set; }
+		/// <summary>
+		/// Gets or sets the category identifier (non-localizable).
+		/// </summary>
+		/// <value>The category identifier.</value>
+		public string CategoryIdentifier { get; set; }
+
+		/// <summary>
+		/// Gets the columns.
+		/// </summary>
+		/// <value>The columns.</value>
+		public List<ColumnDefinition> Columns { get; private set; }
 
         /// <summary>
         /// Gets or sets the converter.
@@ -536,8 +542,14 @@ namespace PropertyTools.Wpf
 		/// <summary>
 		/// Gets or sets the tab sort index.
 		/// </summary>
-		/// <value>The tab.</value>
-		public uint? TabIndex { get; set; }
+		/// <value>The tab sort index.</value>
+		public uint? TabSortIndex { get; set; }
+
+		/// <summary>
+		/// Gets or sets the group sort index.
+		/// </summary>
+		/// <value>The group sort index.</value>
+		public uint? GroupSortIndex { get; set; }
 
 		/// <summary>
 		/// Gets or sets the text wrapping.

--- a/Source/PropertyTools.Wpf/PropertyGrid/Tab.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/Tab.cs
@@ -101,14 +101,20 @@ namespace PropertyTools.Wpf
         /// <value>The icon.</value>
         public BitmapSource Icon { get; set; }
 
-        /// <summary>
-        /// Determines whether the tab contains the specified property.
-        /// </summary>
-        /// <param name="propertyName">Name of the property.</param>
-        /// <returns>
-        /// <c>true</c> if the tab contains the specified property; otherwise, <c>false</c>.
-        /// </returns>
-        public bool Contains(string propertyName)
+		/// <summary>
+		/// Gets or sets the tab sort index.
+		/// </summary>
+		/// <value>The tab sort index.</value>
+		public uint? TabIndex { get; set; }
+
+		/// <summary>
+		/// Determines whether the tab contains the specified property.
+		/// </summary>
+		/// <param name="propertyName">Name of the property.</param>
+		/// <returns>
+		/// <c>true</c> if the tab contains the specified property; otherwise, <c>false</c>.
+		/// </returns>
+		public bool Contains(string propertyName)
         {
             return this.Groups.Any(g => g.Properties.Any(p => p.PropertyName == propertyName));
         }

--- a/Source/PropertyTools.Wpf/PropertyGrid/Tab.cs
+++ b/Source/PropertyTools.Wpf/PropertyGrid/Tab.cs
@@ -149,5 +149,15 @@ namespace PropertyTools.Wpf
             // validate all properties in this tab
             this.HasErrors = this.Groups.Any(g => g.Properties.Any(p => ndei.HasErrors));            
         }
+
+        /// <summary>
+        /// Sort groups by <seealso cref="Group.GroupSortIndex"/>
+        /// </summary>
+        /// <returns></returns>
+        public Tab SortGroups()
+        {
+			this.Groups = this.Groups.OrderBy(x => x.GroupSortIndex ?? 0).ToList();
+            return this;
+		}
     }
 }

--- a/Source/PropertyTools/DataAnnotations/CategoryAttribute.cs
+++ b/Source/PropertyTools/DataAnnotations/CategoryAttribute.cs
@@ -30,11 +30,13 @@ namespace PropertyTools.DataAnnotations
 		/// Initializes a new instance of the <see cref="CategoryAttribute"/> class.
 		/// </summary>
 		/// <param name="category">The category.</param>
-		/// <param name="sortIndex">The category sort index.</param>
-		public CategoryAttribute(string category, uint sortIndex)
+		/// <param name="tabSortIndex">The category sort index (tab scope).</param>
+		/// <param name="groupSortIndex">The category sort index (group scope).</param>
+		public CategoryAttribute(string category, uint tabSortIndex = 0, uint groupSortIndex = 0)
 		{
 			this.Category = category;
-			this.SortIndex = sortIndex;
+			this.TabSortIndex = tabSortIndex;
+			this.GroupSortIndex = groupSortIndex;			
 		}
 
 		/// <summary>
@@ -44,9 +46,15 @@ namespace PropertyTools.DataAnnotations
 		public virtual string Category { get; private set; }
 
 		/// <summary>
-		/// Gets the category sort index
+		/// Gets the category sort index (tab scope)
 		/// </summary>
-		/// <value>The category sort index.</value>
-		public virtual uint? SortIndex { get; private set; }
+		/// <value>The category sort index (tab scope).</value>
+		public virtual uint? TabSortIndex { get; private set; }
+
+		/// <summary>
+		/// Gets the category sort index (group scope)
+		/// </summary>
+		/// <value>The category sort index (group scope).</value>
+		public virtual uint? GroupSortIndex { get; private set; }
 	}
 }

--- a/Source/PropertyTools/DataAnnotations/CategoryAttribute.cs
+++ b/Source/PropertyTools/DataAnnotations/CategoryAttribute.cs
@@ -9,7 +9,7 @@
 
 namespace PropertyTools.DataAnnotations
 {
-    using System;
+	using System;
 
     /// <summary>
     /// Specifies the name of the category in which to group the property or event when displayed in a PropertyGrid control.
@@ -26,10 +26,27 @@ namespace PropertyTools.DataAnnotations
             this.Category = category;
         }
 
-        /// <summary>
-        /// Gets the category.
-        /// </summary>
-        /// <value>The category.</value>
-        public virtual string Category { get; private set; }
-    }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CategoryAttribute"/> class.
+		/// </summary>
+		/// <param name="category">The category.</param>
+		/// <param name="sortIndex">The category sort index.</param>
+		public CategoryAttribute(string category, uint sortIndex)
+		{
+			this.Category = category;
+			this.SortIndex = sortIndex;
+		}
+
+		/// <summary>
+		/// Gets the category.
+		/// </summary>
+		/// <value>The category.</value>
+		public virtual string Category { get; private set; }
+
+		/// <summary>
+		/// Gets the category sort index
+		/// </summary>
+		/// <value>The category sort index.</value>
+		public virtual uint? SortIndex { get; private set; }
+	}
 }


### PR DESCRIPTION
#494

- added Category tab & group sort indecies
- use them when building tabs / groups
- added CategoryAttributeOrderedExample

Also 
- added Group.Name property (non-localizable)
- added PropertyItem.CategoryIdentifier property (non-localizable)

